### PR TITLE
RQLY-345 Handling error on iexplorer.exe launch after windows 11 dropped support for internet explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "scripts": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",

--- a/src/renderer/actions/apps/os/proxy/windows.js
+++ b/src/renderer/actions/apps/os/proxy/windows.js
@@ -1,4 +1,4 @@
-const { exec, execSync } = require("child_process");
+const { spawn, execSync } = require("child_process");
 
 const getProxyAndPort = () => {
   const command = `reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings" /v ProxyServer`;
@@ -51,14 +51,24 @@ const getCurrentProxySetup = () => {
 };
 
 // Hacky trick to refresh proxy settings
-const openAndCloseIE = (close) => {
-  const command_start_ie = `start /w /b iexplore.exe "https://amiusing.requestly.io/"`;
-  const command_kill_ie = `taskkill /f /im iexplore.exe`;
-  exec(command_start_ie);
-  if (close) {
-    setTimeout(() => exec(command_kill_ie), 500);
-  }
-};
+// Not needed in windows 11 and above
+const openAndCloseIE = () => {
+  const command_start_ie = `start /w /b iexplore.exe`
+  const command_kill_ie = `taskkill /f /im iexplore.exe`
+  const ieStartProc = spawn(command_start_ie)
+  ieStartProc.on("error", function(err) {
+      console.log("Expected error while trying to launch internet explorer on windows 11");
+      console.warn("Error when trying to launch internet explorer.");
+      console.warn(err);
+  })
+  setTimeout(() =>{
+      const ieKillProc = spawn(command_kill_ie)
+      ieKillProc.on("error", function(err) {
+          console.log("Expected followup error while trying to kill internet explorer on windows 11");
+          console.warn(err);
+      })
+  }, 500)
+}
 
 const applyProxyWindows = (host, port) => {
   const command_activate_proxy = `reg add "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings" /v ProxyEnable /t REG_DWORD /d 1 /f`;


### PR DESCRIPTION
Before windows 11, in order for system proxy settings to apply, we used a hacky approach to launch and kill a new internet explorer window. 
This is no longer required in windows 11, but with microsoft dropping support for Internet explorer from windows 11 onwards, this launches the following error dialog if we use `exec`


![iexplore exe 24-08-2022 10_36_25](https://user-images.githubusercontent.com/57226514/186333586-fa69a300-46ea-4e75-9fd0-93787be07636.png)
