### PR TITLE
RQLY-440 fix: added meet.google.com to proxy bypass list on OSX

### DIFF
--- a/src/renderer/actions/apps/os/proxy/osx.js
+++ b/src/renderer/actions/apps/os/proxy/osx.js
@@ -1,9 +1,12 @@
+import { promisify } from "util";
+import * as _ from "lodash";
 const { exec } = require("child_process");
+const promisifiedExec = promisify(exec)
 
 let proxyNames = ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"];
 const networkServices = ["Wi-Fi"];
 let desktopProxyNames = ["webproxy", "securewebproxy"];
-const bypassDomains = ["meet.google.com"]
+const RQBypassDomains = ["meet.google.com"]
 
 const proxyCommands = {
   SET_DESKTOP: "SET_DESKTOP",
@@ -14,24 +17,53 @@ const proxyCommands = {
   UNSET_BYPASS: "UNSET_BYPASS",
 };
 
+/* MAINTAINING BYPASS LIST */
+// @nsr move to separate file when providing this as a feature
+let originalBypassDomains = {}
+let bypassDomains = {}
+
+networkServices.forEach(async serviceName => {
+  bypassDomains[serviceName] = await getBypassDomainsList(serviceName);
+})
+
+async function getBypassDomainsList(serviceName) {
+  let cmdOutput = await promisifiedExec(`networksetup -getproxybypassdomains ${serviceName};`)
+  if (
+    !cmdOutput.stderr &&
+    !cmdOutput.stdout.includes("There aren't any bypass domains set") >=0
+  ) {
+    originalBypassDomains[serviceName] = cmdOutput.stdout.trim().split("\n")
+  }
+
+  return _.union(originalBypassDomains[serviceName], RQBypassDomains);
+}
+
+const getBypassString = (service) => {
+  return bypassDomains[service] ? bypassDomains[service].join(" ") : "";
+}
+const getOriginalBypassString = (service) => {
+  return originalBypassDomains[service]?.length ? originalBypassDomains[service].join(" ") : "Empty";
+}
+
 // TODO fix/rewrite:
 // this function just returns the command of commandType
 // but it updates all the other strings too, very inefficient
-const getExecutionCommand = (
+function getExecutionCommand (
   commandType,
   HOST,
   PORT,
   proxyName,
   serviceName
-) => {
-  const bypassList = bypassDomains.join(" ");
+) {
+  const bypassString = getBypassString(serviceName)
+  const originalBypassString = getOriginalBypassString(serviceName)
   const commandTemplates = {
     SET_DESKTOP: `networksetup -set${proxyName} ${serviceName} ${HOST} ${PORT};`,
     UNSET_DESKTOP: `networksetup -set${proxyName}state ${serviceName} off;`,
     SET_TERMINAL: `export ${proxyName}=${HOST}:${PORT};`,
     UNSET_TERMINAL: `unset ${proxyName};`,
-    SET_BYPASS: `networksetup -setproxybypassdomains ${serviceName} ${bypassList};`,
-    UNSET_BYPASS: `networksetup -setproxybypassdomains ${serviceName} Empty;`
+    SET_BYPASS: `networksetup -setproxybypassdomains ${serviceName} ${bypassString};`,
+    UNSET_BYPASS: `networksetup -setproxybypassdomains ${serviceName} ${originalBypassString};`
   };
 
   return commandTemplates[commandType];

--- a/src/renderer/actions/apps/os/proxy/osx.js
+++ b/src/renderer/actions/apps/os/proxy/osx.js
@@ -120,35 +120,35 @@ const executeCommand = (command) => {
 const applyProxyOsx = (HOST, PORT) => {
   proxyNames = ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"];
   desktopProxyNames = ["webproxy", "securewebproxy"];
+  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
   toggleProxy(proxyCommands.SET_DESKTOP, HOST, PORT);
   toggleProxy(proxyCommands.SET_TERMINAL, HOST, PORT);
-  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
 };
 
 // unused
 const applyHttpProxyOsx = (HOST, PORT) => {
   proxyNames = ["http_proxy", "HTTP_PROXY"];
   desktopProxyNames = ["webproxy"];
+  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
   toggleProxy(proxyCommands.SET_DESKTOP, HOST, PORT);
   toggleProxy(proxyCommands.SET_TERMINAL, HOST, PORT);
-  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
 };
 
 // unused
 const applyHttpsProxyOsx = (HOST, PORT) => {
   proxyNames = ["https_proxy", "HTTPS_PROXY"];
   desktopProxyNames = ["securewebproxy"];
+  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
   toggleProxy(proxyCommands.SET_DESKTOP, HOST, PORT);
   toggleProxy(proxyCommands.SET_TERMINAL, HOST, PORT);
-  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
 };
 
 const removeProxyOsx = () => {
   proxyNames = ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"];
   desktopProxyNames = ["webproxy", "securewebproxy"];
+  toggleProxy(proxyCommands.UNSET_BYPASS);
   toggleProxy(proxyCommands.UNSET_DESKTOP);
   toggleProxy(proxyCommands.UNSET_TERMINAL);
-  toggleProxy(proxyCommands.UNSET_BYPASS);
 };
 
 export { applyProxyOsx, applyHttpProxyOsx, applyHttpsProxyOsx, removeProxyOsx };

--- a/src/renderer/actions/apps/os/proxy/osx.js
+++ b/src/renderer/actions/apps/os/proxy/osx.js
@@ -3,14 +3,20 @@ const { exec } = require("child_process");
 let proxyNames = ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"];
 const networkServices = ["Wi-Fi"];
 let desktopProxyNames = ["webproxy", "securewebproxy"];
+const bypassDomains = ["meet.google.com"]
 
 const proxyCommands = {
   SET_DESKTOP: "SET_DESKTOP",
   UNSET_DESKTOP: "UNSET_DESKTOP",
   SET_TERMINAL: "SET_TERMINAL",
   UNSET_TERMINAL: "UNSET_TERMINAL",
+  SET_BYPASS: "SET_BYPASS",
+  UNSET_BYPASS: "UNSET_BYPASS",
 };
 
+// TODO fix/rewrite:
+// this function just returns the command of commandType
+// but it updates all the other strings too, very inefficient
 const getExecutionCommand = (
   commandType,
   HOST,
@@ -18,11 +24,14 @@ const getExecutionCommand = (
   proxyName,
   serviceName
 ) => {
+  const bypassList = bypassDomains.join(" ");
   const commandTemplates = {
     SET_DESKTOP: `networksetup -set${proxyName} ${serviceName} ${HOST} ${PORT};`,
     UNSET_DESKTOP: `networksetup -set${proxyName}state ${serviceName} off;`,
     SET_TERMINAL: `export ${proxyName}=${HOST}:${PORT};`,
     UNSET_TERMINAL: `unset ${proxyName};`,
+    SET_BYPASS: `networksetup -setproxybypassdomains ${serviceName} ${bypassList};`,
+    UNSET_BYPASS: `networksetup -setproxybypassdomains ${serviceName} Empty;`
   };
 
   return commandTemplates[commandType];
@@ -51,24 +60,28 @@ const getTerminalProxyCommand = (proxyCommand, HOST, PORT) => {
 };
 
 const getProxyCommand = (proxyCommand, HOST, PORT) => {
-  if (proxyCommand.indexOf("DESKTOP") >= 0)
+  if (
+    proxyCommand.indexOf("DESKTOP") >= 0 ||
+    proxyCommand.indexOf("BYPASS") >= 0
+  )
     return getDesktopProxyCommand(proxyCommand, HOST, PORT);
   if (proxyCommand.indexOf("TERMINAL") >= 0)
     return getTerminalProxyCommand(proxyCommand, HOST, PORT);
 };
 
+// todo: this is just an executor right now
+// should rewrite this to only toggle services
 const toggleProxy = (proxyCommand, HOST, PORT) => {
   const executionString = getProxyCommand(proxyCommand, HOST, PORT);
-  execute_command(executionString);
+  executeCommand(executionString);
 };
 
-const execute_command = (command) => {
+const executeCommand = (command) => {
   exec(command, (error) => {
     if (error) {
       console.log(error);
       return;
     }
-    console.log(`Proxy Success: ${command}`);
   });
 };
 
@@ -77,20 +90,25 @@ const applyProxyOsx = (HOST, PORT) => {
   desktopProxyNames = ["webproxy", "securewebproxy"];
   toggleProxy(proxyCommands.SET_DESKTOP, HOST, PORT);
   toggleProxy(proxyCommands.SET_TERMINAL, HOST, PORT);
+  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
 };
 
+// unused
 const applyHttpProxyOsx = (HOST, PORT) => {
   proxyNames = ["http_proxy", "HTTP_PROXY"];
   desktopProxyNames = ["webproxy"];
   toggleProxy(proxyCommands.SET_DESKTOP, HOST, PORT);
   toggleProxy(proxyCommands.SET_TERMINAL, HOST, PORT);
+  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
 };
 
+// unused
 const applyHttpsProxyOsx = (HOST, PORT) => {
   proxyNames = ["https_proxy", "HTTPS_PROXY"];
   desktopProxyNames = ["securewebproxy"];
   toggleProxy(proxyCommands.SET_DESKTOP, HOST, PORT);
   toggleProxy(proxyCommands.SET_TERMINAL, HOST, PORT);
+  toggleProxy(proxyCommands.SET_BYPASS, HOST, PORT);
 };
 
 const removeProxyOsx = () => {
@@ -98,6 +116,7 @@ const removeProxyOsx = () => {
   desktopProxyNames = ["webproxy", "securewebproxy"];
   toggleProxy(proxyCommands.UNSET_DESKTOP);
   toggleProxy(proxyCommands.UNSET_TERMINAL);
+  toggleProxy(proxyCommands.UNSET_BYPASS);
 };
 
 export { applyProxyOsx, applyHttpProxyOsx, applyHttpsProxyOsx, removeProxyOsx };


### PR DESCRIPTION
The proxy list is read and not overwritten based on it's value when Requestly is started.
So any changes made while Requestly is running might be overwritten.