### PR TITLE
RQLY-496 temp fix: launch safari with execSync

### DIFF
--- a/src/renderer/actions/apps/browsers/safari.js
+++ b/src/renderer/actions/apps/browsers/safari.js
@@ -42,13 +42,16 @@ export class FreshSafari extends SystemWideProxy {
 
   async activate(proxyPort) {
     await super.activate(proxyPort)
-    const browser = await launchBrowser(
-      null,
-      {
-        browser: "safari",
-      },
-      this.config.configPath
-    );
+    // @nsr uncomment once launchBrowser gets fixed and finds executable for safari
+    // const browser = await launchBrowser(
+    //   null,
+    //   {
+    //     browser: "safari",
+    //   },
+    //   this.config.configPath
+    // );
+
+    execSync("open -b com.apple.Safari")
   }
 }
 


### PR DESCRIPTION
Deactivate does not work. 
Does not seem needed as proxy is applied on system and not on browser

Works well with #7 