### PR TITLE
RQLY-634 chore: remove port IPC calls for launching apps

### DIFF
--- a/src/lib/storage/constants/index.ts
+++ b/src/lib/storage/constants/index.ts
@@ -3,4 +3,4 @@ export enum STORE_NAME {
   USER_PREFERENCE = "UserPreference",
 }
 
-export const DEFAULT_PROXY_PORT = 8080
+export const DEFAULT_PROXY_PORT = 8281

--- a/src/renderer/actions/apps/os/proxy/index.js
+++ b/src/renderer/actions/apps/os/proxy/index.js
@@ -1,15 +1,18 @@
+import { getCurrentProxyPort } from "renderer/actions/storage/cacheUtils";
+
 const { applyProxyOsx, removeProxyOsx } = require("./osx");
 const { applyProxyWindows, removeProxyWindows } = require("./windows");
 
 const applyProxy = (port) => {
+  const targetPort = port ? port : getCurrentProxyPort()
   const host = "127.0.0.1";
 
   switch (process.platform) {
     case "darwin":
-      applyProxyOsx(host, port);
+      applyProxyOsx(host, targetPort);
       break;
     case "win32":
-      applyProxyWindows(host, port);
+      applyProxyWindows(host, targetPort);
       break;
     default:
       console.log(`${process.platform} is not supported for systemwide proxy`);

--- a/src/renderer/actions/initEventHandlers.js
+++ b/src/renderer/actions/initEventHandlers.js
@@ -9,7 +9,6 @@ import {
   areAppsActivatable,
   activateApp,
   deactivateApp,
-  areAppsActivatableAsync,
   isAppActivatable,
 } from "./apps";
 import saveRootCert from "./saveRootCert";
@@ -58,11 +57,11 @@ const initEventHandlers = () => {
   });
 
   ipcRenderer.on("activate-app", async (event, payload) => {
-    const { id, options, proxyPort } = payload;
+    const { id, options } = payload;
     let res = { success: false };
 
     try {
-      res = await activateApp({ id, options, proxyPort });
+      res = await activateApp({ id, options });
     } catch (err) {
       Sentry.captureException(err);
       console.error(err.message);
@@ -71,10 +70,10 @@ const initEventHandlers = () => {
   });
 
   ipcRenderer.on("deactivate-app", async (event, payload) => {
-    const { id, proxyPort } = payload;
+    const { id } = payload;
     let res = { success: false };
     try {
-      res = await deactivateApp({ id, proxyPort });
+      res = await deactivateApp({ id });
     } catch (err) {
       Sentry.captureException(err);
       console.error(err.message);
@@ -104,14 +103,12 @@ const initEventHandlers = () => {
   });
 
   ipcRenderer.on("system-wide-proxy-status", async (event, payload) => {
-    const port = payload.port;
-    const res = getProxyStatus(port);
+    const res = getProxyStatus();
     ipcRenderer.send("reply-system-wide-proxy-status", res);
   });
 
   ipcRenderer.on("system-wide-proxy-start", async (event, payload) => {
-    const port = payload.port;
-    const res = applyProxy(port);
+    const res = applyProxy();
     ipcRenderer.send("reply-system-wide-proxy-start", res);
   });
 

--- a/src/renderer/actions/storage/cacheUtils.ts
+++ b/src/renderer/actions/storage/cacheUtils.ts
@@ -1,0 +1,15 @@
+// todo: move to some appropriate location
+import UserPreferenceFetcher from "renderer/lib/proxy-interface/userPreferenceFetcher";
+
+export const getCurrentProxyPort = () => {
+  console.log("global.rq.proxyServerStatus?.port", global.rq.proxyServerStatus?.port)
+  return global.rq.proxyServerStatus?.port || null
+
+}
+
+
+export const getDefaultProxyPort = () => {
+  // Load user preferences
+  const userPreferences = new UserPreferenceFetcher();
+  return userPreferences.getConfig().defaultPort;
+}

--- a/src/renderer/config/index.js
+++ b/src/renderer/config/index.js
@@ -47,7 +47,7 @@ module.exports.staticConfig = staticConfig;
 const userPreferences = {
   DEFAULT_PROXY_PORT: {
     key: "proxy_port",
-    defaultValue: 8080,
+    defaultValue: 8281,
   },
   START_APP_ON_SYSTEM_STARTUP: {
     key: "start_app_on_system_startup",

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -6,9 +6,17 @@ declare global {
 }
 
 interface RQBgGlobalNamespace {
+  // cache of main storge
   sslProxyingStorage?: SSLProxyingJsonObj;
   sslTunnelingSocketsMap?: SSLTunnelingSocketsMap;
-  userPreferences?: UserPreferenceObj
+  userPreferences?: UserPreferenceObj;
+
+  // local cache for background process
+  proxyServerStatus?: ProxyServerObject
+}
+
+interface ProxyServerObject {
+  port: number
 }
 
 interface SSLTunnelingSocketsMap {


### PR DESCRIPTION
Could had directly used the cache of `UserPreference` store. But to also cover the case when `getNextAvailablePort` might adjust the port number if the cached port number is currently in use:
Added `proxyServerStatus` to the `global.rq` namespace in Background process.

