### PR TITLE
fix: add try catch to handle error during race condition

### DIFF
--- a/src/main/actions/getProxiedAxios.ts
+++ b/src/main/actions/getProxiedAxios.ts
@@ -33,17 +33,21 @@ export const createOrUpdateAxiosInstance = (
     ...newProxyConfig,
   };
 
-  axiosInstance = axios.create({
-    proxy: false,
-    httpAgent: new HttpsProxyAgent(
-      `http://${proxyConfig.ip}:${proxyConfig.port}`
-    ),
-    httpsAgent: new PatchedHttpsProxyAgent({
-      host: proxyConfig.ip,
-      port: proxyConfig.port,
-      ca: readFileSync(proxyConfig.rootCertPath),
-    }),
-  });
+  try {
+    axiosInstance = axios.create({
+      proxy: false,
+      httpAgent: new HttpsProxyAgent(
+        `http://${proxyConfig.ip}:${proxyConfig.port}`
+      ),
+      httpsAgent: new PatchedHttpsProxyAgent({
+        host: proxyConfig.ip,
+        port: proxyConfig.port,
+        ca: readFileSync(proxyConfig.rootCertPath),
+      }),
+    });
+  } catch {
+    /* Do nothing */
+  }
 
   return axiosInstance;
 };


### PR DESCRIPTION
fixes https://github.com/requestly/requestly/issues/652

currently shows a blocking error dialog for fresh installs.
This happens because of a race condition between saving the certificate locally and the api client reading it for creating the axios client.

