### PR TITLE
feat: set requestly protocol handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,12 @@
       "static"
     ],
     "afterSign": ".erb/scripts/notarize.js",
+    "protocols": {
+      "name": "requestly-internal-protocol",
+      "schemes": [
+        "requestly"
+      ]
+    },
     "mac": {
       "type": "distribution",
       "hardenedRuntime": true,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -216,10 +216,13 @@ const createWindow = async () => {
 
 // custom protocol (requestly) handler
 app.on("open-url", (_event, rqUrl) => {
+  webAppWindow?.show();
+  webAppWindow?.focus();
   const url = new URL(rqUrl);
+  // note: currently action agnostic, because it is only meant for redirection for now
   if(url.searchParams.has("route")) {
     const route = url.searchParams.get("route")
-    webAppWindow?.webContents.send("redirect-from-web-app", route)
+    webAppWindow?.webContents.send("deeplink-handler", route)
   }
 })
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -243,6 +243,15 @@ app.on("ready", () => {
     // Register Remaining IPC Events that involve browser windows
     registerMainProcessEventsForWebAppWindow(webAppWindow);
     registerMainProcessCommonEvents();
+
+    if (process.platform === 'win32') {
+      // Set the path of electron.exe and your app.
+      // These two additional parameters are only available on windows.
+      // Setting this is required to get this working in dev mode.
+      app.setAsDefaultProtocolClient('requestly', process.execPath, [path.resolve(process.argv[1])]);
+    } else {
+      app.setAsDefaultProtocolClient('requestly');
+    }
   });
   loadingScreenWindow.loadURL(
     `file://${path.resolve(__dirname, "../loadingScreen/", "index.html")}`

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -208,15 +208,20 @@ const createWindow = async () => {
   menuBuilder.buildMenu();
 
   // Open urls in the user's browser
-  // webAppWindow.webContents.on("new-window", (event, url) => { // deprecated after electron v22
   webAppWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url);
     return { action: 'deny' }
   });
-
-  // Remove this if your app does not use auto updates
-  // eslint-disable-next-line
 };
+
+// custom protocol (requestly) handler
+app.on("open-url", (_event, rqUrl) => {
+  const url = new URL(rqUrl);
+  if(url.searchParams.has("route")) {
+    const route = url.searchParams.get("route")
+    webAppWindow?.webContents.send("redirect-from-web-app", route)
+  }
+})
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.


### PR DESCRIPTION
App will registers itself as a client for `requestly://` protocol
Also added support to force redirects when navigated to desktop app using this protocol.
Specify the path you want to redirect to using the `route` search param as such `requestly://desktop-app?route=/path/to/something`

The supporting pr for this (https://github.com/requestly/requestly/pull/692) includes utilities for the same