### PR TITLE
Use notarytool 

### DIFF
--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -1,6 +1,8 @@
 const { notarize } = require("@electron/notarize");
 const { build } = require("../../package.json");
 
+// NO LONGER USED
+
 exports.default = async function notarizeMacos(context) {
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== "darwin") {
@@ -23,9 +25,11 @@ exports.default = async function notarizeMacos(context) {
   const appName = context.packager.appInfo.productFilename;
 
   await notarize({
+    tool: "notarytool",
     appBundleId: build.appId,
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
-    appleIdPassword: process.env.APPLE_ID_PASS,
+    appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
+    teamId: process.env.APPLE_TEAM_ID
   });
 };

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
       "package.json",
       "static"
     ],
-    "afterSign": ".erb/scripts/notarize.js",
     "protocols": {
       "name": "requestly-internal-protocol",
       "schemes": [
@@ -61,6 +60,9 @@
       "gatekeeperAssess": false,
       "requirements": "assets/requirement.rqset",
       "identity": "RQ LABS, INC. (B7SH28MF39)",
+      "notarize" : {
+        "teamId" : "B7SH28MF39"
+      },
       "target": [
         {
           "target": "dmg",


### PR DESCRIPTION
Changes around notarization steps for macOS
- start using `notarytool` instead of the long deprecated `alttool` 
- stops redundant internal calls to notarize (electron builder is the one who actually triggers notarization)
- renders `.erb/scripts/notarize.js` useless (still added fixes, in case we decide to switch in the future)

Now the build will only require `APPLE_APP_SPECIFIC_PASSWORD` and `APPLE_ID` to be correctly set in the environment

Verified auto upgrade flow does not break!