### PR TITLE
chore: update requestly-proxy to v1.1.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
   "dependencies": {
     "@electron/remote": "^2.0.9",
     "@requestly/requestly-core": "^1.0.3",
-    "@requestly/requestly-proxy": "^1.1.22",
+    "@requestly/requestly-proxy": "^1.1.23",
     "@sentry/browser": "^6.13.3",
     "@sentry/electron": "^2.5.4",
     "assert": "^2.0.0",


### PR DESCRIPTION
rollout fix for failing secure websockets - https://github.com/requestly/requestly-proxy/pull/26