### PR TITLE
chore: version bump to v1.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "requestly",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@electron/remote": "^2.0.9",
-        "@requestly/requestly-core": "^1.0.3",
+        "@requestly/requestly-core": "^1.0.4",
         "@requestly/requestly-proxy": "^1.1.23",
         "@sentry/browser": "^6.13.3",
         "@sentry/electron": "^2.5.4",
@@ -1686,9 +1686,9 @@
       "license": "MIT"
     },
     "node_modules/@requestly/requestly-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-core/-/requestly-core-1.0.3.tgz",
-      "integrity": "sha512-PQlznW8VmcSrViVEgm1uxM77lJZr+JRw4RCR8dWVECLe5qwZL2brwG4XNaMkm4vxrjzYOUaDoGzwLq0sWJwSNg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-core/-/requestly-core-1.0.4.tgz",
+      "integrity": "sha512-aRPJjoafFkNuz1Pq6Ctz9If+GA8N0hx7vovWdskEh7a1sGVjpBtXLUT1sZkLZqZ2qnCtwmJR2+ZPPHsc5sgU1A=="
     },
     "node_modules/@requestly/requestly-proxy": {
       "version": "1.1.23",
@@ -16576,9 +16576,9 @@
       "dev": true
     },
     "@requestly/requestly-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-core/-/requestly-core-1.0.3.tgz",
-      "integrity": "sha512-PQlznW8VmcSrViVEgm1uxM77lJZr+JRw4RCR8dWVECLe5qwZL2brwG4XNaMkm4vxrjzYOUaDoGzwLq0sWJwSNg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-core/-/requestly-core-1.0.4.tgz",
+      "integrity": "sha512-aRPJjoafFkNuz1Pq6Ctz9If+GA8N0hx7vovWdskEh7a1sGVjpBtXLUT1sZkLZqZ2qnCtwmJR2+ZPPHsc5sgU1A=="
     },
     "@requestly/requestly-proxy": {
       "version": "1.1.23",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "scripts": {
@@ -238,7 +238,7 @@
   },
   "dependencies": {
     "@electron/remote": "^2.0.9",
-    "@requestly/requestly-core": "^1.0.3",
+    "@requestly/requestly-core": "^1.0.4",
     "@requestly/requestly-proxy": "^1.1.23",
     "@sentry/browser": "^6.13.3",
     "@sentry/electron": "^2.5.4",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -1245,6 +1245,14 @@
       "version": "1.2.0",
       "license": "ISC"
     },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@httptoolkit/httpolyglot": {
       "version": "2.1.1",
       "dependencies": {
@@ -2262,6 +2270,14 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -3929,6 +3945,11 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1"
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",
@@ -5693,6 +5714,11 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1"
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
upgrades requestly core to enable new internal debugging feature
shipping this: https://github.com/requestly/requestly/pull/1027