### PR TITLE
feat: delete old RootCA from trust store on regeneration

### DIFF
--- a/src/renderer/actions/apps/os/ca/osx.js
+++ b/src/renderer/actions/apps/os/ca/osx.js
@@ -1,6 +1,6 @@
-const { exec, execSync } = require("child_process");
+const { execSync } = require("child_process");
 
-const installOsxCert = async (cert_path) => {
+const installOsxCert = async (certPath) => {
   // const command = `security add-trusted-cert \
   // -d -r trustRoot \
   // -k $HOME/Library/Keychains/login.keychain "${cert_path}"\
@@ -18,7 +18,7 @@ const installOsxCert = async (cert_path) => {
     'do shell script \
     "security add-trusted-cert \
     -r trustRoot \
-    -k $HOME/Library/Keychains/login.keychain \\"${cert_path}\\"\
+    -k $HOME/Library/Keychains/login.keychain \\"${certPath}\\"\
     " with prompt "Requestly wants to store SSL certificate to keychain."'`;
 
   try {
@@ -31,4 +31,19 @@ const installOsxCert = async (cert_path) => {
   }
 };
 
-export { installOsxCert };
+const deleteOsxCert = async (caName) => {
+  const command = `osascript -e \
+    'do shell script \
+    "security delete-certificate -c \\"${caName}\\" $HOME/Library/Keychains/login.keychain \
+    " with prompt "Requestly wants to remove SSL certificate from keychain."'`;
+  try {
+    execSync(command);
+    console.log(`${command} executed succesfully`);
+    return true;
+  } catch (err) {
+    console.log(err);
+    return false;
+  }
+};
+
+export { installOsxCert, deleteOsxCert };

--- a/src/renderer/actions/apps/os/ca/utils.js
+++ b/src/renderer/actions/apps/os/ca/utils.js
@@ -1,4 +1,6 @@
-const { exec, execSync } = require("child_process");
+import { deleteOsxCert } from "./osx";
+
+const { execSync } = require("child_process");
 
 export const isCertificateInstalled = () => {
   let status = false;
@@ -27,7 +29,8 @@ export const isCertificateInstalled = () => {
 };
 
 const is_rq_cert_trusted = (trust_settings_str) => {
-  let re = /(Cert \d+: RQProxyCA[\s\S]*?(?=Cert))|(Cert \d+: RQProxyCA[\s\S]*)/gm;
+  let re =
+    /(Cert \d+: RQProxyCA[\s\S]*?(?=Cert))|(Cert \d+: RQProxyCA[\s\S]*)/gm;
   const rq_cert_settings = re.exec(trust_settings_str);
 
   if (
@@ -56,6 +59,19 @@ export const isCertificateTrusted = () => {
     default:
       console.log(`${process.platform} is not supported for systemwide proxy`);
       return false;
+  }
+};
+
+export const handleCARegeneration = (pathToNewCA) => {
+  console.log("new CA generated at", pathToNewCA);
+  switch (process.platform) {
+    case "darwin": {
+      deleteOsxCert("RQProxyCA");
+      break;
+    }
+    default: {
+      console.log("No extra steps after CA regeneration");
+    }
   }
 };
 

--- a/src/renderer/actions/proxy/startProxyServer.ts
+++ b/src/renderer/actions/proxy/startProxyServer.ts
@@ -13,6 +13,7 @@ import * as Sentry from "@sentry/browser";
 import startHelperServer from "../startHelperServer";
 import logger from "utils/logger";
 import { getDefaultProxyPort } from "../storage/cacheUtils";
+import { handleCARegeneration} from "../apps/os/ca/utils";
 
 declare global {
   interface Window { proxy: any }
@@ -87,6 +88,7 @@ function startProxyFromModule(PROXY_PORT: number) {
     // @ts-ignore
     certPath: CERTS_PATH,
     rootCertPath: ROOT_CERT_PATH,
+    onCARegenerated: handleCARegeneration,
   };
   RQProxyProvider.createInstance(
     proxyConfig,


### PR DESCRIPTION
Uses the newly added `onCARegenerated` hook - https://github.com/requestly/requestly-proxy/pull/29

Fixes: 
- https://github.com/requestly/requestly/issues/1225
- https://github.com/requestly/requestly/issues/1224