### PR TITLE
Fix: windows code signing process

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,9 +96,9 @@
       ]
     },
     "win": {
-      "target": [
-        "nsis"
-      ]
+      "certificateSubjectName" : "RQ Labs, Inc.",
+      "rfc3161TimeStampServer":"http://sha256timestamp.ws.symantec.com/sha256/timestamp",
+      "target": ["nsis"]
     },
     "linux": {
       "target": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "scripts": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
updated windows metadata to make it possible to sign app with physical ev.

Note: `rfc3161TimeStampServer` can be occasionally removed while signing to try the default time stamping server when this one fails