### PR TITLE
chore: electron version bump to v27

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -267,15 +267,21 @@ export default merge(baseConfig, {
       verbose: true,
       disableDotRule: false,
     },
-    onBeforeSetupMiddleware() {
+    setupMiddlewares: (middlewares, devServer) => {
+      if (!devServer) {
+          throw new Error('webpack-dev-server is not defined');
+      }
+
       console.log("Starting Main Process...");
       spawn("npm", ["run", "start:main"], {
-        shell: true,
-        env: process.env,
-        stdio: "inherit",
+          shell: true,
+          env: process.env,
+          stdio: "inherit",
       })
-        .on("close", (code) => process.exit(code))
-        .on("error", (spawnError) => console.error(spawnError));
-    },
+      .on("close", (code) => process.exit(code))
+      .on("error", (spawnError) => console.error(spawnError));
+
+      return middlewares; // make sure to return the middlewares array
+  },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "tmp": "^0.2.1",
+        "ts-node": "^10.9.2",
         "ua-parser-js": "^1.0.2",
         "util": "^0.12.4",
         "uuid": "^9.0.0",
@@ -61,7 +62,7 @@
       },
       "devDependencies": {
         "@electron/notarize": "^1.2.3",
-        "@electron/rebuild": "^3.2.10",
+        "@electron/rebuild": "^3.6.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
         "@teamsupercell/typings-for-css-modules-loader": "^2.5.1",
         "@testing-library/jest-dom": "^5.14.1",
@@ -69,7 +70,7 @@
         "@types/history": "4.7.9",
         "@types/ip": "^1.1.0",
         "@types/jest": "^27.0.2",
-        "@types/node": "16.10.8",
+        "@types/node": "17.0.23",
         "@types/terser-webpack-plugin": "^5.0.4",
         "@types/webpack-env": "^1.16.3",
         "browserslist-config-erb": "^0.0.3",
@@ -80,7 +81,7 @@
         "css-loader": "^6.4.0",
         "css-minimizer-webpack-plugin": "^3.1.1",
         "detect-port": "^1.3.0",
-        "electron": "^23.3.13",
+        "electron": "^27.3.8",
         "electron-builder": "^24.13.3",
         "electron-devtools-installer": "^3.2.0",
         "enzyme": "^3.11.0",
@@ -103,8 +104,7 @@
         "terser-webpack-plugin": "^5.2.4",
         "ts-jest": "^27.0.5",
         "ts-loader": "^9.2.6",
-        "ts-node": "^10.3.0",
-        "typescript": "^4.4.4",
+        "typescript": "^4.9.5",
         "url-loader": "^4.1.1",
         "webpack": "^5.58.2",
         "webpack-bundle-analyzer": "^4.5.0",
@@ -769,7 +769,6 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -780,7 +779,6 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -973,9 +971,10 @@
       }
     },
     "node_modules/@electron/rebuild": {
-      "version": "3.2.13",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.0.tgz",
+      "integrity": "sha512-zF4x3QupRU3uNGaP5X1wjpmcjfw1H87kyqZ00Tc3HvriV+4gmOGuvQjGNkrJuXdsApssdNyVwLsy+TaeTGGcVw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
@@ -983,10 +982,11 @@
         "detect-libc": "^2.0.1",
         "fs-extra": "^10.0.0",
         "got": "^11.7.0",
-        "node-abi": "^3.0.0",
-        "node-api-version": "^0.1.4",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
         "node-gyp": "^9.0.0",
         "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
         "semver": "^7.3.5",
         "tar": "^6.0.5",
         "yargs": "^17.0.1"
@@ -1672,7 +1672,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1697,7 +1696,6 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2390,22 +2388,18 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -2539,9 +2533,10 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.17",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -2667,8 +2662,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.10.8",
-      "license": "MIT"
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -3246,7 +3242,6 @@
     },
     "node_modules/acorn": {
       "version": "8.8.2",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3654,7 +3649,6 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -5390,7 +5384,6 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-env": {
@@ -6020,7 +6013,6 @@
     },
     "node_modules/diff": {
       "version": "4.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -6319,13 +6311,13 @@
       }
     },
     "node_modules/electron": {
-      "version": "23.3.13",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.13.tgz",
-      "integrity": "sha512-BaXtHEb+KYKLouUXlUVDa/lj9pj4F5kiE0kwFdJV84Y2EU7euIDgPthfKtchhr5MVHmjtavRMIV/zAwEiSQ9rQ==",
+      "version": "27.3.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.8.tgz",
+      "integrity": "sha512-CLQ4rhFiXBzfYsEuxDHqQlnw4fI5tJVMA+xqW322LkfcP6iiFjAMh/gYe3a1JqGPNMO2bff2Ev7toAxP1opRnQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -6500,8 +6492,12 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "16.18.34",
-      "license": "MIT"
+      "version": "18.19.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.28.tgz",
+      "integrity": "sha512-J5cOGD9n4x3YGgVuaND6khm5x07MMdAKkRyXnjVR6KFhLMNh2yONGiP7Z+4+tBOt5mK+GvDTiacTOVGGpqiecw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/elliptic": {
       "version": "6.5.5",
@@ -8094,9 +8090,11 @@
       "license": "ISC"
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
-      "license": "MIT",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -11142,7 +11140,6 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
@@ -11646,9 +11643,10 @@
       "license": "0BSD"
     },
     "node_modules/node-abi": {
-      "version": "3.43.0",
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
+      "integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -11664,9 +11662,10 @@
       "optional": true
     },
     "node_modules/node-api-version": {
-      "version": "0.1.4",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.0.tgz",
+      "integrity": "sha512-fthTTsi8CxaBXMaBAD7ST2uylwvsnYxh2PfaScwpMhos6KlSFajXQPcM4ogNE1q2s3Lbz9GCGqeIHC+C6OZnKg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       }
@@ -13359,6 +13358,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
       }
     },
     "node_modules/read-config-file": {
@@ -15236,9 +15247,9 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15279,7 +15290,6 @@
     },
     "node_modules/ts-node/node_modules/acorn-walk": {
       "version": "8.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -15405,8 +15415,8 @@
     },
     "node_modules/typescript": {
       "version": "4.9.5",
-      "dev": true,
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15450,6 +15460,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unique-filename": {
       "version": "2.0.1",
@@ -15652,7 +15667,6 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -16457,7 +16471,6 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16985,14 +16998,12 @@
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
       "dependencies": {
         "@jridgewell/trace-mapping": {
           "version": "0.3.9",
-          "dev": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
             "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -17132,7 +17143,9 @@
       }
     },
     "@electron/rebuild": {
-      "version": "3.2.13",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.0.tgz",
+      "integrity": "sha512-zF4x3QupRU3uNGaP5X1wjpmcjfw1H87kyqZ00Tc3HvriV+4gmOGuvQjGNkrJuXdsApssdNyVwLsy+TaeTGGcVw==",
       "dev": true,
       "requires": {
         "@malept/cross-spawn-promise": "^2.0.0",
@@ -17141,10 +17154,11 @@
         "detect-libc": "^2.0.1",
         "fs-extra": "^10.0.0",
         "got": "^11.7.0",
-        "node-abi": "^3.0.0",
-        "node-api-version": "^0.1.4",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
         "node-gyp": "^9.0.0",
         "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
         "semver": "^7.3.5",
         "tar": "^6.0.5",
         "yargs": "^17.0.1"
@@ -17623,8 +17637,7 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -17639,8 +17652,7 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "dev": true
+      "version": "1.4.15"
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.18",
@@ -18121,20 +18133,16 @@
       "dev": true
     },
     "@tsconfig/node10": {
-      "version": "1.0.9",
-      "dev": true
+      "version": "1.0.9"
     },
     "@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true
+      "version": "1.0.11"
     },
     "@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "@tsconfig/node16": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "@types/babel__core": {
       "version": "7.20.1",
@@ -18253,7 +18261,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.17",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -18366,7 +18376,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.10.8"
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -18776,8 +18788,7 @@
       }
     },
     "acorn": {
-      "version": "8.8.2",
-      "dev": true
+      "version": "8.8.2"
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -19067,8 +19078,7 @@
       }
     },
     "arg": {
-      "version": "4.1.3",
-      "dev": true
+      "version": "4.1.3"
     },
     "argparse": {
       "version": "2.0.1"
@@ -20281,8 +20291,7 @@
       }
     },
     "create-require": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "cross-env": {
       "version": "7.0.3",
@@ -20662,8 +20671,7 @@
       }
     },
     "diff": {
-      "version": "4.0.2",
-      "dev": true
+      "version": "4.0.2"
     },
     "diff-sequences": {
       "version": "27.5.1",
@@ -20879,17 +20887,22 @@
       }
     },
     "electron": {
-      "version": "23.3.13",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.13.tgz",
-      "integrity": "sha512-BaXtHEb+KYKLouUXlUVDa/lj9pj4F5kiE0kwFdJV84Y2EU7euIDgPthfKtchhr5MVHmjtavRMIV/zAwEiSQ9rQ==",
+      "version": "27.3.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.8.tgz",
+      "integrity": "sha512-CLQ4rhFiXBzfYsEuxDHqQlnw4fI5tJVMA+xqW322LkfcP6iiFjAMh/gYe3a1JqGPNMO2bff2Ev7toAxP1opRnQ==",
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "16.18.34"
+          "version": "18.19.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.28.tgz",
+          "integrity": "sha512-J5cOGD9n4x3YGgVuaND6khm5x07MMdAKkRyXnjVR6KFhLMNh2yONGiP7Z+4+tBOt5mK+GvDTiacTOVGGpqiecw==",
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -22123,7 +22136,9 @@
       "version": "1.0.0"
     },
     "fsevents": {
-      "version": "2.3.2",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
     },
@@ -24131,8 +24146,7 @@
       }
     },
     "make-error": {
-      "version": "1.3.6",
-      "dev": true
+      "version": "1.3.6"
     },
     "make-fetch-happen": {
       "version": "10.2.1",
@@ -24453,7 +24467,9 @@
       }
     },
     "node-abi": {
-      "version": "3.43.0",
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
+      "integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
       "dev": true,
       "requires": {
         "semver": "^7.3.5"
@@ -24467,7 +24483,9 @@
       "optional": true
     },
     "node-api-version": {
-      "version": "0.1.4",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.0.tgz",
+      "integrity": "sha512-fthTTsi8CxaBXMaBAD7ST2uylwvsnYxh2PfaScwpMhos6KlSFajXQPcM4ogNE1q2s3Lbz9GCGqeIHC+C6OZnKg==",
       "dev": true,
       "requires": {
         "semver": "^7.3.5"
@@ -25506,6 +25524,15 @@
     "react-refresh": {
       "version": "0.14.0",
       "dev": true
+    },
+    "read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4"
+      }
     },
     "read-config-file": {
       "version": "6.3.2",
@@ -26725,8 +26752,9 @@
       }
     },
     "ts-node": {
-      "version": "10.9.1",
-      "dev": true,
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -26744,8 +26772,7 @@
       },
       "dependencies": {
         "acorn-walk": {
-          "version": "8.2.0",
-          "dev": true
+          "version": "8.2.0"
         }
       }
     },
@@ -26830,7 +26857,8 @@
     },
     "typescript": {
       "version": "4.9.5",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "ua-parser-js": {
       "version": "1.0.37",
@@ -26846,6 +26874,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unique-filename": {
       "version": "2.0.1",
@@ -26974,8 +27007,7 @@
       "version": "9.0.0"
     },
     "v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "v8-to-istanbul": {
       "version": "8.1.1",
@@ -27492,8 +27524,7 @@
       }
     },
     "yn": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "requestly",
   "productName": "Requestly",
   "version": "1.6.0",
+  "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "scripts": {
@@ -74,8 +75,8 @@
       "gatekeeperAssess": false,
       "requirements": "assets/requirement.rqset",
       "identity": "RQ LABS, INC. (B7SH28MF39)",
-      "notarize" : {
-        "teamId" : "B7SH28MF39"
+      "notarize": {
+        "teamId": "B7SH28MF39"
       },
       "target": [
         {
@@ -110,9 +111,11 @@
       ]
     },
     "win": {
-      "certificateSubjectName" : "RQ Labs, Inc.",
-      "rfc3161TimeStampServer":"http://sha256timestamp.ws.symantec.com/sha256/timestamp",
-      "target": ["nsis"]
+      "certificateSubjectName": "RQ Labs, Inc.",
+      "rfc3161TimeStampServer": "http://sha256timestamp.ws.symantec.com/sha256/timestamp",
+      "target": [
+        "nsis"
+      ]
     },
     "linux": {
       "target": [
@@ -199,7 +202,7 @@
   },
   "devDependencies": {
     "@electron/notarize": "^1.2.3",
-    "@electron/rebuild": "^3.2.10",
+    "@electron/rebuild": "^3.6.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
     "@teamsupercell/typings-for-css-modules-loader": "^2.5.1",
     "@testing-library/jest-dom": "^5.14.1",
@@ -207,7 +210,7 @@
     "@types/history": "4.7.9",
     "@types/ip": "^1.1.0",
     "@types/jest": "^27.0.2",
-    "@types/node": "16.10.8",
+    "@types/node": "17.0.23",
     "@types/terser-webpack-plugin": "^5.0.4",
     "@types/webpack-env": "^1.16.3",
     "browserslist-config-erb": "^0.0.3",
@@ -218,7 +221,7 @@
     "css-loader": "^6.4.0",
     "css-minimizer-webpack-plugin": "^3.1.1",
     "detect-port": "^1.3.0",
-    "electron": "^23.3.13",
+    "electron": "^27.3.8",
     "electron-builder": "^24.13.3",
     "electron-devtools-installer": "^3.2.0",
     "enzyme": "^3.11.0",
@@ -241,8 +244,7 @@
     "terser-webpack-plugin": "^5.2.4",
     "ts-jest": "^27.0.5",
     "ts-loader": "^9.2.6",
-    "ts-node": "^10.3.0",
-    "typescript": "^4.4.4",
+    "typescript": "^4.9.5",
     "url-loader": "^4.1.1",
     "webpack": "^5.58.2",
     "webpack-bundle-analyzer": "^4.5.0",
@@ -294,6 +296,7 @@
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "tmp": "^0.2.1",
+    "ts-node": "^10.9.2",
     "ua-parser-js": "^1.0.2",
     "util": "^0.12.4",
     "uuid": "^9.0.0",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -16,7 +16,7 @@
         "ws": "^8.16.0"
       },
       "devDependencies": {
-        "electron": "23.0.0",
+        "electron": "^27.3.8",
         "npm-force-resolutions": "0.0.10"
       }
     },
@@ -437,6 +437,15 @@
       "engines": {
         "node": ">=4.0.0",
         "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "18.19.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.28.tgz",
+      "integrity": "sha512-J5cOGD9n4x3YGgVuaND6khm5x07MMdAKkRyXnjVR6KFhLMNh2yONGiP7Z+4+tBOt5mK+GvDTiacTOVGGpqiecw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/prebuild-install": {
@@ -876,9 +885,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.34",
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.1",
@@ -943,14 +956,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.0.0.tgz",
-      "integrity": "sha512-S6hVtTAjauMiiWP9sBVR5RpcUC464cNZ06I2EMUjeZBq+KooS6tLmNsfw0zLpAXDp1qosjlBP3v71NTZ3gd9iA==",
+      "version": "27.3.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.8.tgz",
+      "integrity": "sha512-CLQ4rhFiXBzfYsEuxDHqQlnw4fI5tJVMA+xqW322LkfcP6iiFjAMh/gYe3a1JqGPNMO2bff2Ev7toAxP1opRnQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -1942,6 +1955,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/lodash._basetostring": {
       "version": "4.12.0",
       "license": "MIT"
@@ -2135,8 +2154,13 @@
       }
     },
     "@types/node": {
-      "version": "16.18.34",
-      "dev": true
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/responselike": {
       "version": "1.0.0",
@@ -2405,14 +2429,25 @@
       "optional": true
     },
     "electron": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.0.0.tgz",
-      "integrity": "sha512-S6hVtTAjauMiiWP9sBVR5RpcUC464cNZ06I2EMUjeZBq+KooS6tLmNsfw0zLpAXDp1qosjlBP3v71NTZ3gd9iA==",
+      "version": "27.3.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.8.tgz",
+      "integrity": "sha512-CLQ4rhFiXBzfYsEuxDHqQlnw4fI5tJVMA+xqW322LkfcP6iiFjAMh/gYe3a1JqGPNMO2bff2Ev7toAxP1opRnQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.19.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.28.tgz",
+          "integrity": "sha512-J5cOGD9n4x3YGgVuaND6khm5x07MMdAKkRyXnjVR6KFhLMNh2yONGiP7Z+4+tBOt5mK+GvDTiacTOVGGpqiecw==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "emoji-regex": {
@@ -3251,6 +3286,12 @@
       "requires": {
         "@lukeed/csprng": "^1.0.0"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -24,11 +24,12 @@
     "ws": "^8.16.0"
   },
   "devDependencies": {
-    "electron": "23.0.0",
+    "electron": "^27.3.8",
     "npm-force-resolutions": "0.0.10"
   },
   "resolutions": {
     "bufferutil": "4.0.3",
     "utf-8-validate": "5.0.6"
+    
   }
 }


### PR DESCRIPTION
- could not bump to v29 since it has some issues with the ts transpiler. [This issue](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3568) gives a good overview and can be referenced later during the next upgrade. Also - https://github.com/TypeStrong/ts-node/issues/1997
- updated `webpack.config.renderer.dev` to avoid a deprecated warning
- a critical vulnerability still exists inside the `releases/app` but that is due to a [not-yet-fixed lodash release](https://github.com/advisories/GHSA-p6mc-m468-83gw) (lodash.patch)