### PR TITLE
chore: update electron-updater to remove security vulnerability.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "electron-log": "^4.4.1",
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^8.0.1",
-        "electron-updater": "^5.3.0",
+        "electron-updater": "^6.3.2",
         "es6-promisify": "^7.0.0",
         "fs-extra": "^10.0.0",
         "headless": "^1.2.0",
@@ -2856,6 +2856,7 @@
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -6600,23 +6601,24 @@
       "dev": true
     },
     "node_modules/electron-updater": {
-      "version": "5.3.0",
-      "license": "MIT",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.3.2.tgz",
+      "integrity": "sha512-bEpuZ1IRnMtvZZaWeYi9ocX90Cnk+/impZ/08r6GQkfOMqECtKC2IjvxHcDk2VpWO8QZzK0+MUNaBiO81CGvQQ==",
       "dependencies": {
-        "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.1.1",
-        "fs-extra": "^10.0.0",
+        "builder-util-runtime": "9.2.5",
+        "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
-        "semver": "^7.3.5",
-        "typed-emitter": "^2.1.0"
+        "semver": "^7.3.8",
+        "tiny-typed-emitter": "^2.1.0"
       }
     },
     "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.1.1",
-      "license": "MIT",
+      "version": "9.2.5",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.5.tgz",
+      "integrity": "sha512-HjIDfhvqx/8B3TDN4GbABQcgpewTU4LMRTQPkVpKYV3lsuxEJoIfvg09GyWTNmfVNSUAYf+fbTN//JX4TH20pg==",
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -13941,7 +13943,7 @@
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^1.9.0"
@@ -15227,6 +15229,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "license": "MIT",
@@ -15548,13 +15555,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-emitter": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "rxjs": "*"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -18686,7 +18686,8 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.5.0"
+      "version": "7.5.0",
+      "dev": true
     },
     "@types/send": {
       "version": "0.17.1",
@@ -21287,21 +21288,24 @@
       "dev": true
     },
     "electron-updater": {
-      "version": "5.3.0",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.3.2.tgz",
+      "integrity": "sha512-bEpuZ1IRnMtvZZaWeYi9ocX90Cnk+/impZ/08r6GQkfOMqECtKC2IjvxHcDk2VpWO8QZzK0+MUNaBiO81CGvQQ==",
       "requires": {
-        "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.1.1",
-        "fs-extra": "^10.0.0",
+        "builder-util-runtime": "9.2.5",
+        "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
-        "semver": "^7.3.5",
-        "typed-emitter": "^2.1.0"
+        "semver": "^7.3.8",
+        "tiny-typed-emitter": "^2.1.0"
       },
       "dependencies": {
         "builder-util-runtime": {
-          "version": "9.1.1",
+          "version": "9.2.5",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.5.tgz",
+          "integrity": "sha512-HjIDfhvqx/8B3TDN4GbABQcgpewTU4LMRTQPkVpKYV3lsuxEJoIfvg09GyWTNmfVNSUAYf+fbTN//JX4TH20pg==",
           "requires": {
             "debug": "^4.3.4",
             "sax": "^1.2.4"
@@ -26085,7 +26089,7 @@
     },
     "rxjs": {
       "version": "6.6.7",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -26933,6 +26937,11 @@
       "version": "1.1.0",
       "dev": true
     },
+    "tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
     "tmp": {
       "version": "0.2.1",
       "requires": {
@@ -27124,12 +27133,6 @@
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
         "is-typed-array": "^1.1.9"
-      }
-    },
-    "typed-emitter": {
-      "version": "2.1.0",
-      "requires": {
-        "rxjs": "*"
       }
     },
     "typedarray-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
     "electron-log": "^4.4.1",
     "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^8.0.1",
-    "electron-updater": "^5.3.0",
+    "electron-updater": "^6.3.2",
     "es6-promisify": "^7.0.0",
     "fs-extra": "^10.0.0",
     "headless": "^1.2.0",


### PR DESCRIPTION
yet to be properly tested inside requestly-desktop-dev, but mergin for now.