### PR TITLE
fix: api client not working for errored requests

### DIFF
--- a/src/main/actions/makeApiClientRequest.js
+++ b/src/main/actions/makeApiClientRequest.js
@@ -40,6 +40,7 @@ const makeApiClientRequest = async ({ apiRequest }) => {
       data: body,
       responseType: "arraybuffer",
       withCredentials: false,
+      validateStatus: false,
     });
     const responseTime = performance.now() - requestStartTime;
 


### PR DESCRIPTION
When API client request throw error status code, it was leading to an exception

![CleanShot 2024-09-23 at 04 09 05@2x](https://github.com/user-attachments/assets/2076dbb1-6632-48df-b5e3-7ac4a341486f)


![CleanShot 2024-09-23 at 04 10 51@2x](https://github.com/user-attachments/assets/24408e65-2bfc-4904-bb18-a259d8c74a2b)


