### PR TITLE
chore: cleanup and minor fixes + update requestly-core version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
       "dependencies": {
         "@devicefarmer/adbkit": "^3.2.6",
         "@electron/remote": "^2.1.2",
-        "@requestly/requestly-core": "^1.0.4",
+        "@requestly/requestly-core": "^1.0.5",
         "@requestly/requestly-proxy": "^1.3.2",
         "@sentry/browser": "^6.13.3",
-        "@sentry/electron": "^2.5.4",
+        "@sentry/electron": "^5.6.0",
         "address": "^2.0.3",
         "assert": "^2.0.0",
         "async": "^3.2.1",
@@ -104,9 +104,8 @@
         "sass-loader": "^12.2.0",
         "style-loader": "^3.3.0",
         "terser-webpack-plugin": "^5.2.4",
-        "ts-jest": "^27.0.5",
         "ts-loader": "^9.2.6",
-        "typescript": "^4.9.5",
+        "typescript": "^5.6.3",
         "url-loader": "^4.1.1",
         "webpack": "^5.58.2",
         "webpack-bundle-analyzer": "^4.5.0",
@@ -1916,6 +1915,489 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.42.0.tgz",
+      "integrity": "sha512-fiuU6OKsqHJiydHWgTRQ7MnIrJ2lEqsdgFtNIH4LbAUJl/5XmrIeoDzDnox+hfkgWK65jsleFuQDtYb5hW1koQ==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.39.0.tgz",
+      "integrity": "sha512-pGBiKevLq7NNglMgqzmeKczF4XQMTOUOTkK8afRHMZMnrK3fcETyTH7lVaSozwiOM3Ws+SuEmXZT7DYrrhxGlg==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.36"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.12.0.tgz",
+      "integrity": "sha512-pnPxatoFE0OXIZDQhL2okF//dmbiWFzcSc8pUg9TqofCLYZySSxDCgQc69CJBo5JnI3Gz1KP+mOjS4WAeRIH4g==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.42.0.tgz",
+      "integrity": "sha512-YNcy7ZfGnLsVEqGXQPT+S0G1AE46N21ORY7i7yUQyfhGAL4RBjnZUqefMI0NwqIl6nGbr1IpF0rZGoN8Q7x12Q==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fastify": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.39.0.tgz",
+      "integrity": "sha512-SS9uSlKcsWZabhBp2szErkeuuBDgxOUlllwkS92dVaWRnMmwysPhcEgHKB8rUe3BHg/GnZC1eo1hbTZv4YhfoA==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.15.0.tgz",
+      "integrity": "sha512-JWVKdNLpu1skqZQA//jKOcKdJC66TWKqa2FUFq70rKohvaSq47pmXlnabNO+B/BvLfmidfiaN35XakT5RyMl2Q==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.39.0.tgz",
+      "integrity": "sha512-y4v8Y+tSfRB3NNBvHjbjrn7rX/7sdARG7FuK6zR8PGb28CTa0kHpEGCJqvL9L8xkTNvTXo+lM36ajFGUaK1aNw==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.43.0.tgz",
+      "integrity": "sha512-aI3YMmC2McGd8KW5du1a2gBA0iOMOGLqg4s9YjzwbjFwjlmMNFSK1P3AIg374GWg823RPUGfVTIgZ/juk9CVOA==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.41.0.tgz",
+      "integrity": "sha512-jKDrxPNXDByPlYcMdZjNPYCvw0SQJjN+B1A+QH+sx+sAHsKSAf9hwFiJSrI6C4XdOls43V/f/fkp9ITkHhKFbQ==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.53.0.tgz",
+      "integrity": "sha512-H74ErMeDuZfj7KgYCTOFGWF5W9AfaPnqLQQxeFq85+D29wwV2yqHbz2IKLYpkOh7EI6QwDEl7rZCIxjJLyc/CQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.43.0.tgz",
+      "integrity": "sha512-i3Dke/LdhZbiUAEImmRG3i7Dimm/BD7t8pDDzwepSvIQ6s2X6FPia7561gw+64w+nx0+G9X14D7rEfaMEmmjig==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.3.0.tgz",
+      "integrity": "sha512-UnkZueYK1ise8FXQeKlpBd7YYUtC7mM8J0wzUSccEfc/G8UqHQqAzIyYCUOUPUKp8GsjLnWOOK/3hJc4owb7Jg==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.43.0.tgz",
+      "integrity": "sha512-lDAhSnmoTIN6ELKmLJBplXzT/Jqs5jGZehuG22EdSMaTwgjMpxMDI1YtlKEhiWPWkrz5LUsd0aOO0ZRc9vn3AQ==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.40.0.tgz",
+      "integrity": "sha512-21xRwZsEdMPnROu/QsaOIODmzw59IYpGFmuC4aFWvMj6stA8+Ei1tX67nkarJttlNjoM94um0N4X26AD7ff54A==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.47.0.tgz",
+      "integrity": "sha512-yqyXRx2SulEURjgOQyJzhCECSh5i1uM49NUaq9TqLd6fA7g26OahyJfsr9NE38HFqGRHpi4loyrnfYGdrsoVjQ==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/sdk-metrics": "^1.9.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.42.0.tgz",
+      "integrity": "sha512-AnWv+RaR86uG3qNEMwt3plKX1ueRM7AspfszJYVkvkehiicC3bHQA6vWdb6Zvy5HAE14RyFbu9+2hUUjR2NSyg==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.41.0.tgz",
+      "integrity": "sha512-jnvrV6BsQWyHS2qb2fkfbfSb1R/lmYwqEZITwufuRl37apTopswu9izc0b1CYRp/34tUG/4k/V39PND6eyiNvw==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.26"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.41.0.tgz",
+      "integrity": "sha512-REQB0x+IzVTpoNgVmy5b+UnH1/mDByrneimP6sbDHkp1j8QOl1HyWOrBH/6YWR0nrbU3l825Em5PlybjT3232g==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-nestjs-core": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.40.0.tgz",
+      "integrity": "sha512-WF1hCUed07vKmf5BzEkL0wSPinqJgH7kGzOjjMAiTGacofNXjb/y4KQ8loj2sNsh5C/NN7s1zxQuCgbWbVTGKg==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.44.0.tgz",
+      "integrity": "sha512-oTWVyzKqXud1BYEGX1loo2o4k4vaU1elr3vPO8NZolrBtFvQ34nx4HgUaexUDuEog00qQt+MLR5gws/p+JXMLQ==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.6"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.42.0.tgz",
+      "integrity": "sha512-NaD+t2JNcOzX/Qa7kMy68JbmoVIV37fT/fJYzLKu2Wwd+0NCxt+K2OOsOakA8GVg8lSpFdbx4V/suzZZ2Pvdjg==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.6.0.tgz",
+      "integrity": "sha512-ABJBhm5OdhGmbh0S/fOTE4N69IZ00CsHC5ijMYfzbw3E5NwLgpQk5xsljaECrJ8wz1SfXbO03FiSuu5AyRAkvQ==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
+      "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
+      "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
+      "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1980,10 +2462,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@prisma/instrumentation": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.19.1.tgz",
+      "integrity": "sha512-VLnzMQq7CWroL5AeaW0Py2huiNKeoMfCH3SUxstdzPrlWQi6UQ9UrfcbUkNHlVFqOMacqy8X/8YtE0kuKDpD9w==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.8",
+        "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0",
+        "@opentelemetry/sdk-trace-base": "^1.22"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
+      "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@requestly/requestly-core": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-core/-/requestly-core-1.0.4.tgz",
-      "integrity": "sha512-aRPJjoafFkNuz1Pq6Ctz9If+GA8N0hx7vovWdskEh7a1sGVjpBtXLUT1sZkLZqZ2qnCtwmJR2+ZPPHsc5sgU1A=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-core/-/requestly-core-1.0.5.tgz",
+      "integrity": "sha512-RrDvx+aKtQJctuFjp7ihDSmcRKQQgE9/gqNmZUKh9muSVvCav7RVANQWyuAVV1zZBVKeEQc+SYAqTgK05Yg8uQ=="
     },
     "node_modules/@requestly/requestly-proxy": {
       "version": "1.3.2",
@@ -2096,6 +2618,184 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.33.1.tgz",
+      "integrity": "sha512-TW6/r+Gl5jiXv54iK1xZ3mlVgTS/jaBp4vcQ0xGMdgiQ3WchEPcFSeYovL+YHT3tSud0GZqVtDQCz+5i76puqA==",
+      "dependencies": {
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/core": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+      "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
+      "dependencies": {
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/types": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
+      "dependencies": {
+        "@sentry/types": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.33.1.tgz",
+      "integrity": "sha512-qauMRTm3qDaLqZ3ibI03cj4gLF40y0ij65nj+cns6iWxGCtPrO8tjvXFWuQsE7Aye9dGMnBgmv7uN+NTUtC3RA==",
+      "dependencies": {
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+      "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
+      "dependencies": {
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/types": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
+      "dependencies": {
+        "@sentry/types": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.33.1.tgz",
+      "integrity": "sha512-fm4coIOjmanU29NOVN9MyaP4fUCOYytbtFqVSKRFNZQ/xAgNeySiBIbUd6IjujMmnOk9bY0WEUMcdm3Uotjdog==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.33.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.33.1.tgz",
+      "integrity": "sha512-nsxTFTPCT10Ty/v6+AiST3+yotGP1sUb8xqfKB9fPnS1hZHFryp0NnEls7xFjBsBbZPU1GpFkzrk/E6JFzixDQ==",
+      "dependencies": {
+        "@sentry-internal/replay": "8.33.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+      "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
+      "dependencies": {
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/types": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
+      "dependencies": {
+        "@sentry/types": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/core": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+      "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
+      "dependencies": {
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/types": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
+      "dependencies": {
+        "@sentry/types": "8.33.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/browser": {
       "version": "6.19.7",
       "license": "BSD-3-Clause",
@@ -2124,110 +2824,65 @@
       }
     },
     "node_modules/@sentry/electron": {
-      "version": "2.5.4",
-      "license": "MIT",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-5.6.0.tgz",
+      "integrity": "sha512-nRxrij5S6NAQtKanGgSmR6If00ra0s4Kg+Posm5XbzKxA/KnnfretECW+Vf+HqwefcusuPtySuI/I+AqRKkFMg==",
       "dependencies": {
-        "@sentry/browser": "6.7.1",
-        "@sentry/core": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/node": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^2.2.0"
+        "@sentry/browser": "8.33.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/node": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1",
+        "deepmerge": "4.3.1"
       }
     },
     "node_modules/@sentry/electron/node_modules/@sentry/browser": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.33.1.tgz",
+      "integrity": "sha512-c6zI/igexkLwZuGk+u8Rj26ChjxGgkhe6ZbKFsXCYaKAp5ep5X7HQRkkqgbxApiqlC0LduHdd/ymzh139JLg8w==",
       "dependencies": {
-        "@sentry/core": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry-internal/browser-utils": "8.33.1",
+        "@sentry-internal/feedback": "8.33.1",
+        "@sentry-internal/replay": "8.33.1",
+        "@sentry-internal/replay-canvas": "8.33.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
     },
     "node_modules/@sentry/electron/node_modules/@sentry/core": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+      "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
       "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/hub": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/minimal": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/minimal/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
     },
     "node_modules/@sentry/electron/node_modules/@sentry/types": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/electron/node_modules/@sentry/utils": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
       "dependencies": {
-        "@sentry/types": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.33.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
-    },
-    "node_modules/@sentry/electron/node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/electron/node_modules/tslib": {
-      "version": "2.5.2",
-      "license": "0BSD"
     },
     "node_modules/@sentry/hub": {
       "version": "6.19.7",
@@ -2254,133 +2909,130 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.33.1.tgz",
+      "integrity": "sha512-0Xmlrl5nU5Bx6YybaIfztyOIiIXW5X64vcK0u94Sg4uHcDO7YvEbhflKjp669ds2I6ZQ/czqxnaAY8gM6P2SCA==",
       "dependencies": {
-        "@sentry/core": "6.7.1",
-        "@sentry/hub": "6.7.1",
-        "@sentry/tracing": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.25.1",
+        "@opentelemetry/core": "^1.25.1",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.42.0",
+        "@opentelemetry/instrumentation-connect": "0.39.0",
+        "@opentelemetry/instrumentation-dataloader": "0.12.0",
+        "@opentelemetry/instrumentation-express": "0.42.0",
+        "@opentelemetry/instrumentation-fastify": "0.39.0",
+        "@opentelemetry/instrumentation-fs": "0.15.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.39.0",
+        "@opentelemetry/instrumentation-graphql": "0.43.0",
+        "@opentelemetry/instrumentation-hapi": "0.41.0",
+        "@opentelemetry/instrumentation-http": "0.53.0",
+        "@opentelemetry/instrumentation-ioredis": "0.43.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.3.0",
+        "@opentelemetry/instrumentation-koa": "0.43.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.40.0",
+        "@opentelemetry/instrumentation-mongodb": "0.47.0",
+        "@opentelemetry/instrumentation-mongoose": "0.42.0",
+        "@opentelemetry/instrumentation-mysql": "0.41.0",
+        "@opentelemetry/instrumentation-mysql2": "0.41.0",
+        "@opentelemetry/instrumentation-nestjs-core": "0.40.0",
+        "@opentelemetry/instrumentation-pg": "0.44.0",
+        "@opentelemetry/instrumentation-redis-4": "0.42.0",
+        "@opentelemetry/instrumentation-undici": "0.6.0",
+        "@opentelemetry/resources": "^1.26.0",
+        "@opentelemetry/sdk-trace-base": "^1.26.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@prisma/instrumentation": "5.19.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/opentelemetry": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1",
+        "import-in-the-middle": "^1.11.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/core": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+      "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
       "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/@sentry/hub": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/@sentry/minimal": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/types": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/utils": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
       "dependencies": {
-        "@sentry/types": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.33.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry/tracing": {
-      "version": "6.7.1",
-      "license": "MIT",
+    "node_modules/@sentry/opentelemetry": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.33.1.tgz",
+      "integrity": "sha512-D2aE2G0DUHLLnfbOXrTjiNJKAs/RZfOBJMidI4fC2AIwqCmrp55Aex4dRq4hxd8MPLR92Kt/ikHeJxlzWB15KA==",
       "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.25.1",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/sdk-trace-base": "^1.26.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
       }
     },
-    "node_modules/@sentry/tracing/node_modules/@sentry/hub": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/core": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+      "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
       "dependencies": {
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry/tracing/node_modules/@sentry/minimal": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/types": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
       "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.33.1"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/tracing/node_modules/@sentry/types": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/tracing/node_modules/@sentry/utils": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/types": {
@@ -2629,9 +3281,9 @@
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.35",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2789,6 +3441,14 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -2807,6 +3467,24 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "dependencies": {
+        "@types/pg": "*"
+      }
     },
     "node_modules/@types/plist": {
       "version": "3.0.5",
@@ -2896,6 +3574,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
@@ -3429,7 +4112,6 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
       "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -4487,17 +5169,6 @@
         "electron": ">=12.0.0"
       }
     },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bser": {
       "version": "2.1.1",
       "dev": true,
@@ -4947,7 +5618,6 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/clean-css": {
@@ -5357,19 +6027,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/config-file-ts/node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "dev": true,
@@ -5412,13 +6069,6 @@
       "version": "1.9.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
@@ -5940,10 +6590,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "license": "MIT",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -6022,7 +6673,6 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7822,9 +8472,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -7832,7 +8482,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -7869,9 +8519,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -9276,6 +9926,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.11.2.tgz",
+      "integrity": "sha512-gK6Rr6EykBcc6cVWRSBR5TWf8nn6hZMYSRYqCcHa0l0d1fPK7JSYo6+Mlmck76jIX9aL/IZ71c06U2VpFwl1zA==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "dev": true,
@@ -9475,11 +10136,14 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11289,10 +11953,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
@@ -11725,6 +12385,11 @@
         "mkdirp": ">=0.5.0"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+    },
     "node_modules/moo": {
       "version": "0.5.2",
       "dev": true,
@@ -11739,8 +12404,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -12440,7 +13106,6 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -12520,6 +13185,34 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
+      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -13218,6 +13911,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -13786,17 +14514,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz",
+      "integrity": "sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -14231,12 +14972,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "license": "MIT",
@@ -14435,6 +15170,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/side-channel": {
       "version": "1.0.6",
@@ -15007,7 +15747,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15413,48 +16152,6 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "node_modules/ts-jest": {
-      "version": "27.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^27.0.0",
-        "json5": "2.x",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "20.x"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@types/jest": "^27.0.0",
-        "babel-jest": ">=27.0.0 <28",
-        "jest": "^27.0.0",
-        "typescript": ">=3.8 <5.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@types/jest": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ts-loader": {
       "version": "9.4.3",
       "dev": true,
@@ -15634,15 +16331,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {
@@ -17994,6 +18691,304 @@
         "rimraf": "^3.0.2"
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+    },
+    "@opentelemetry/api-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+      "requires": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "@opentelemetry/context-async-hooks": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
+      "requires": {}
+    },
+    "@opentelemetry/core": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+      "requires": {
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
+      "requires": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      }
+    },
+    "@opentelemetry/instrumentation-amqplib": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.42.0.tgz",
+      "integrity": "sha512-fiuU6OKsqHJiydHWgTRQ7MnIrJ2lEqsdgFtNIH4LbAUJl/5XmrIeoDzDnox+hfkgWK65jsleFuQDtYb5hW1koQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-connect": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.39.0.tgz",
+      "integrity": "sha512-pGBiKevLq7NNglMgqzmeKczF4XQMTOUOTkK8afRHMZMnrK3fcETyTH7lVaSozwiOM3Ws+SuEmXZT7DYrrhxGlg==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.36"
+      }
+    },
+    "@opentelemetry/instrumentation-dataloader": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.12.0.tgz",
+      "integrity": "sha512-pnPxatoFE0OXIZDQhL2okF//dmbiWFzcSc8pUg9TqofCLYZySSxDCgQc69CJBo5JnI3Gz1KP+mOjS4WAeRIH4g==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0"
+      }
+    },
+    "@opentelemetry/instrumentation-express": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.42.0.tgz",
+      "integrity": "sha512-YNcy7ZfGnLsVEqGXQPT+S0G1AE46N21ORY7i7yUQyfhGAL4RBjnZUqefMI0NwqIl6nGbr1IpF0rZGoN8Q7x12Q==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-fastify": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.39.0.tgz",
+      "integrity": "sha512-SS9uSlKcsWZabhBp2szErkeuuBDgxOUlllwkS92dVaWRnMmwysPhcEgHKB8rUe3BHg/GnZC1eo1hbTZv4YhfoA==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-fs": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.15.0.tgz",
+      "integrity": "sha512-JWVKdNLpu1skqZQA//jKOcKdJC66TWKqa2FUFq70rKohvaSq47pmXlnabNO+B/BvLfmidfiaN35XakT5RyMl2Q==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0"
+      }
+    },
+    "@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.39.0.tgz",
+      "integrity": "sha512-y4v8Y+tSfRB3NNBvHjbjrn7rX/7sdARG7FuK6zR8PGb28CTa0kHpEGCJqvL9L8xkTNvTXo+lM36ajFGUaK1aNw==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0"
+      }
+    },
+    "@opentelemetry/instrumentation-graphql": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.43.0.tgz",
+      "integrity": "sha512-aI3YMmC2McGd8KW5du1a2gBA0iOMOGLqg4s9YjzwbjFwjlmMNFSK1P3AIg374GWg823RPUGfVTIgZ/juk9CVOA==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0"
+      }
+    },
+    "@opentelemetry/instrumentation-hapi": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.41.0.tgz",
+      "integrity": "sha512-jKDrxPNXDByPlYcMdZjNPYCvw0SQJjN+B1A+QH+sx+sAHsKSAf9hwFiJSrI6C4XdOls43V/f/fkp9ITkHhKFbQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-http": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.53.0.tgz",
+      "integrity": "sha512-H74ErMeDuZfj7KgYCTOFGWF5W9AfaPnqLQQxeFq85+D29wwV2yqHbz2IKLYpkOh7EI6QwDEl7rZCIxjJLyc/CQ==",
+      "requires": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
+        "semver": "^7.5.2"
+      }
+    },
+    "@opentelemetry/instrumentation-ioredis": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.43.0.tgz",
+      "integrity": "sha512-i3Dke/LdhZbiUAEImmRG3i7Dimm/BD7t8pDDzwepSvIQ6s2X6FPia7561gw+64w+nx0+G9X14D7rEfaMEmmjig==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.3.0.tgz",
+      "integrity": "sha512-UnkZueYK1ise8FXQeKlpBd7YYUtC7mM8J0wzUSccEfc/G8UqHQqAzIyYCUOUPUKp8GsjLnWOOK/3hJc4owb7Jg==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-koa": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.43.0.tgz",
+      "integrity": "sha512-lDAhSnmoTIN6ELKmLJBplXzT/Jqs5jGZehuG22EdSMaTwgjMpxMDI1YtlKEhiWPWkrz5LUsd0aOO0ZRc9vn3AQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.40.0.tgz",
+      "integrity": "sha512-21xRwZsEdMPnROu/QsaOIODmzw59IYpGFmuC4aFWvMj6stA8+Ei1tX67nkarJttlNjoM94um0N4X26AD7ff54A==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0"
+      }
+    },
+    "@opentelemetry/instrumentation-mongodb": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.47.0.tgz",
+      "integrity": "sha512-yqyXRx2SulEURjgOQyJzhCECSh5i1uM49NUaq9TqLd6fA7g26OahyJfsr9NE38HFqGRHpi4loyrnfYGdrsoVjQ==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/sdk-metrics": "^1.9.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-mongoose": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.42.0.tgz",
+      "integrity": "sha512-AnWv+RaR86uG3qNEMwt3plKX1ueRM7AspfszJYVkvkehiicC3bHQA6vWdb6Zvy5HAE14RyFbu9+2hUUjR2NSyg==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-mysql": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.41.0.tgz",
+      "integrity": "sha512-jnvrV6BsQWyHS2qb2fkfbfSb1R/lmYwqEZITwufuRl37apTopswu9izc0b1CYRp/34tUG/4k/V39PND6eyiNvw==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.26"
+      }
+    },
+    "@opentelemetry/instrumentation-mysql2": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.41.0.tgz",
+      "integrity": "sha512-REQB0x+IzVTpoNgVmy5b+UnH1/mDByrneimP6sbDHkp1j8QOl1HyWOrBH/6YWR0nrbU3l825Em5PlybjT3232g==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1"
+      }
+    },
+    "@opentelemetry/instrumentation-nestjs-core": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.40.0.tgz",
+      "integrity": "sha512-WF1hCUed07vKmf5BzEkL0wSPinqJgH7kGzOjjMAiTGacofNXjb/y4KQ8loj2sNsh5C/NN7s1zxQuCgbWbVTGKg==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-pg": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.44.0.tgz",
+      "integrity": "sha512-oTWVyzKqXud1BYEGX1loo2o4k4vaU1elr3vPO8NZolrBtFvQ34nx4HgUaexUDuEog00qQt+MLR5gws/p+JXMLQ==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.6"
+      }
+    },
+    "@opentelemetry/instrumentation-redis-4": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.42.0.tgz",
+      "integrity": "sha512-NaD+t2JNcOzX/Qa7kMy68JbmoVIV37fT/fJYzLKu2Wwd+0NCxt+K2OOsOakA8GVg8lSpFdbx4V/suzZZ2Pvdjg==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-undici": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.6.0.tgz",
+      "integrity": "sha512-ABJBhm5OdhGmbh0S/fOTE4N69IZ00CsHC5ijMYfzbw3E5NwLgpQk5xsljaECrJ8wz1SfXbO03FiSuu5AyRAkvQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.53.0"
+      }
+    },
+    "@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g=="
+    },
+    "@opentelemetry/resources": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
+      "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
+      "requires": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      }
+    },
+    "@opentelemetry/sdk-metrics": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
+      "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
+      "requires": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
+      "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
+      "requires": {
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg=="
+    },
+    "@opentelemetry/sql-common": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "requires": {
+        "@opentelemetry/core": "^1.1.0"
+      }
+    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -18020,10 +19015,43 @@
       "version": "1.0.0-next.21",
       "dev": true
     },
+    "@prisma/instrumentation": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.19.1.tgz",
+      "integrity": "sha512-VLnzMQq7CWroL5AeaW0Py2huiNKeoMfCH3SUxstdzPrlWQi6UQ9UrfcbUkNHlVFqOMacqy8X/8YtE0kuKDpD9w==",
+      "requires": {
+        "@opentelemetry/api": "^1.8",
+        "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0",
+        "@opentelemetry/sdk-trace-base": "^1.22"
+      },
+      "dependencies": {
+        "@opentelemetry/api-logs": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+          "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/instrumentation": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
+          "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+          "requires": {
+            "@opentelemetry/api-logs": "0.52.1",
+            "@types/shimmer": "^1.0.2",
+            "import-in-the-middle": "^1.8.1",
+            "require-in-the-middle": "^7.1.1",
+            "semver": "^7.5.2",
+            "shimmer": "^1.2.1"
+          }
+        }
+      }
+    },
     "@requestly/requestly-core": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-core/-/requestly-core-1.0.4.tgz",
-      "integrity": "sha512-aRPJjoafFkNuz1Pq6Ctz9If+GA8N0hx7vovWdskEh7a1sGVjpBtXLUT1sZkLZqZ2qnCtwmJR2+ZPPHsc5sgU1A=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-core/-/requestly-core-1.0.5.tgz",
+      "integrity": "sha512-RrDvx+aKtQJctuFjp7ihDSmcRKQQgE9/gqNmZUKh9muSVvCav7RVANQWyuAVV1zZBVKeEQc+SYAqTgK05Yg8uQ=="
     },
     "@requestly/requestly-proxy": {
       "version": "1.3.2",
@@ -18123,6 +19151,144 @@
         }
       }
     },
+    "@sentry-internal/browser-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.33.1.tgz",
+      "integrity": "sha512-TW6/r+Gl5jiXv54iK1xZ3mlVgTS/jaBp4vcQ0xGMdgiQ3WchEPcFSeYovL+YHT3tSud0GZqVtDQCz+5i76puqA==",
+      "requires": {
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+          "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
+          "requires": {
+            "@sentry/types": "8.33.1",
+            "@sentry/utils": "8.33.1"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+          "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA=="
+        },
+        "@sentry/utils": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+          "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
+          "requires": {
+            "@sentry/types": "8.33.1"
+          }
+        }
+      }
+    },
+    "@sentry-internal/feedback": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.33.1.tgz",
+      "integrity": "sha512-qauMRTm3qDaLqZ3ibI03cj4gLF40y0ij65nj+cns6iWxGCtPrO8tjvXFWuQsE7Aye9dGMnBgmv7uN+NTUtC3RA==",
+      "requires": {
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+          "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
+          "requires": {
+            "@sentry/types": "8.33.1",
+            "@sentry/utils": "8.33.1"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+          "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA=="
+        },
+        "@sentry/utils": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+          "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
+          "requires": {
+            "@sentry/types": "8.33.1"
+          }
+        }
+      }
+    },
+    "@sentry-internal/replay": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.33.1.tgz",
+      "integrity": "sha512-fm4coIOjmanU29NOVN9MyaP4fUCOYytbtFqVSKRFNZQ/xAgNeySiBIbUd6IjujMmnOk9bY0WEUMcdm3Uotjdog==",
+      "requires": {
+        "@sentry-internal/browser-utils": "8.33.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+          "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
+          "requires": {
+            "@sentry/types": "8.33.1",
+            "@sentry/utils": "8.33.1"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+          "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA=="
+        },
+        "@sentry/utils": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+          "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
+          "requires": {
+            "@sentry/types": "8.33.1"
+          }
+        }
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.33.1.tgz",
+      "integrity": "sha512-nsxTFTPCT10Ty/v6+AiST3+yotGP1sUb8xqfKB9fPnS1hZHFryp0NnEls7xFjBsBbZPU1GpFkzrk/E6JFzixDQ==",
+      "requires": {
+        "@sentry-internal/replay": "8.33.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+          "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
+          "requires": {
+            "@sentry/types": "8.33.1",
+            "@sentry/utils": "8.33.1"
+          }
+        },
+        "@sentry/types": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+          "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA=="
+        },
+        "@sentry/utils": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+          "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
+          "requires": {
+            "@sentry/types": "8.33.1"
+          }
+        }
+      }
+    },
     "@sentry/browser": {
       "version": "6.19.7",
       "requires": {
@@ -18143,89 +19309,53 @@
       }
     },
     "@sentry/electron": {
-      "version": "2.5.4",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-5.6.0.tgz",
+      "integrity": "sha512-nRxrij5S6NAQtKanGgSmR6If00ra0s4Kg+Posm5XbzKxA/KnnfretECW+Vf+HqwefcusuPtySuI/I+AqRKkFMg==",
       "requires": {
-        "@sentry/browser": "6.7.1",
-        "@sentry/core": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/node": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^2.2.0"
+        "@sentry/browser": "8.33.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/node": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1",
+        "deepmerge": "4.3.1"
       },
       "dependencies": {
         "@sentry/browser": {
-          "version": "6.7.1",
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.33.1.tgz",
+          "integrity": "sha512-c6zI/igexkLwZuGk+u8Rj26ChjxGgkhe6ZbKFsXCYaKAp5ep5X7HQRkkqgbxApiqlC0LduHdd/ymzh139JLg8w==",
           "requires": {
-            "@sentry/core": "6.7.1",
-            "@sentry/types": "6.7.1",
-            "@sentry/utils": "6.7.1",
-            "tslib": "^1.9.3"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1"
-            }
+            "@sentry-internal/browser-utils": "8.33.1",
+            "@sentry-internal/feedback": "8.33.1",
+            "@sentry-internal/replay": "8.33.1",
+            "@sentry-internal/replay-canvas": "8.33.1",
+            "@sentry/core": "8.33.1",
+            "@sentry/types": "8.33.1",
+            "@sentry/utils": "8.33.1"
           }
         },
         "@sentry/core": {
-          "version": "6.7.1",
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+          "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
           "requires": {
-            "@sentry/hub": "6.7.1",
-            "@sentry/minimal": "6.7.1",
-            "@sentry/types": "6.7.1",
-            "@sentry/utils": "6.7.1",
-            "tslib": "^1.9.3"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1"
-            }
-          }
-        },
-        "@sentry/hub": {
-          "version": "6.7.1",
-          "requires": {
-            "@sentry/types": "6.7.1",
-            "@sentry/utils": "6.7.1",
-            "tslib": "^1.9.3"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1"
-            }
-          }
-        },
-        "@sentry/minimal": {
-          "version": "6.7.1",
-          "requires": {
-            "@sentry/hub": "6.7.1",
-            "@sentry/types": "6.7.1",
-            "tslib": "^1.9.3"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1"
-            }
+            "@sentry/types": "8.33.1",
+            "@sentry/utils": "8.33.1"
           }
         },
         "@sentry/types": {
-          "version": "6.7.1"
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+          "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA=="
         },
         "@sentry/utils": {
-          "version": "6.7.1",
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+          "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
           "requires": {
-            "@sentry/types": "6.7.1",
-            "tslib": "^1.9.3"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1"
-            }
+            "@sentry/types": "8.33.1"
           }
-        },
-        "tslib": {
-          "version": "2.5.2"
         }
       }
     },
@@ -18246,91 +19376,101 @@
       }
     },
     "@sentry/node": {
-      "version": "6.7.1",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.33.1.tgz",
+      "integrity": "sha512-0Xmlrl5nU5Bx6YybaIfztyOIiIXW5X64vcK0u94Sg4uHcDO7YvEbhflKjp669ds2I6ZQ/czqxnaAY8gM6P2SCA==",
       "requires": {
-        "@sentry/core": "6.7.1",
-        "@sentry/hub": "6.7.1",
-        "@sentry/tracing": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.25.1",
+        "@opentelemetry/core": "^1.25.1",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.42.0",
+        "@opentelemetry/instrumentation-connect": "0.39.0",
+        "@opentelemetry/instrumentation-dataloader": "0.12.0",
+        "@opentelemetry/instrumentation-express": "0.42.0",
+        "@opentelemetry/instrumentation-fastify": "0.39.0",
+        "@opentelemetry/instrumentation-fs": "0.15.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.39.0",
+        "@opentelemetry/instrumentation-graphql": "0.43.0",
+        "@opentelemetry/instrumentation-hapi": "0.41.0",
+        "@opentelemetry/instrumentation-http": "0.53.0",
+        "@opentelemetry/instrumentation-ioredis": "0.43.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.3.0",
+        "@opentelemetry/instrumentation-koa": "0.43.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.40.0",
+        "@opentelemetry/instrumentation-mongodb": "0.47.0",
+        "@opentelemetry/instrumentation-mongoose": "0.42.0",
+        "@opentelemetry/instrumentation-mysql": "0.41.0",
+        "@opentelemetry/instrumentation-mysql2": "0.41.0",
+        "@opentelemetry/instrumentation-nestjs-core": "0.40.0",
+        "@opentelemetry/instrumentation-pg": "0.44.0",
+        "@opentelemetry/instrumentation-redis-4": "0.42.0",
+        "@opentelemetry/instrumentation-undici": "0.6.0",
+        "@opentelemetry/resources": "^1.26.0",
+        "@opentelemetry/sdk-trace-base": "^1.26.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@prisma/instrumentation": "5.19.1",
+        "@sentry/core": "8.33.1",
+        "@sentry/opentelemetry": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1",
+        "import-in-the-middle": "^1.11.0"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "6.7.1",
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+          "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
           "requires": {
-            "@sentry/hub": "6.7.1",
-            "@sentry/minimal": "6.7.1",
-            "@sentry/types": "6.7.1",
-            "@sentry/utils": "6.7.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/hub": {
-          "version": "6.7.1",
-          "requires": {
-            "@sentry/types": "6.7.1",
-            "@sentry/utils": "6.7.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/minimal": {
-          "version": "6.7.1",
-          "requires": {
-            "@sentry/hub": "6.7.1",
-            "@sentry/types": "6.7.1",
-            "tslib": "^1.9.3"
+            "@sentry/types": "8.33.1",
+            "@sentry/utils": "8.33.1"
           }
         },
         "@sentry/types": {
-          "version": "6.7.1"
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+          "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA=="
         },
         "@sentry/utils": {
-          "version": "6.7.1",
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+          "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
           "requires": {
-            "@sentry/types": "6.7.1",
-            "tslib": "^1.9.3"
+            "@sentry/types": "8.33.1"
           }
         }
       }
     },
-    "@sentry/tracing": {
-      "version": "6.7.1",
+    "@sentry/opentelemetry": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.33.1.tgz",
+      "integrity": "sha512-D2aE2G0DUHLLnfbOXrTjiNJKAs/RZfOBJMidI4fC2AIwqCmrp55Aex4dRq4hxd8MPLR92Kt/ikHeJxlzWB15KA==",
       "requires": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/core": "8.33.1",
+        "@sentry/types": "8.33.1",
+        "@sentry/utils": "8.33.1"
       },
       "dependencies": {
-        "@sentry/hub": {
-          "version": "6.7.1",
+        "@sentry/core": {
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.33.1.tgz",
+          "integrity": "sha512-3SS41suXLFzxL3OQvTMZ6q92ZapELVq2l2SoWlZopcamWhog2Ru0dp2vkunq97kFHb2TzKRTlFH4+4gbT8SJug==",
           "requires": {
-            "@sentry/types": "6.7.1",
-            "@sentry/utils": "6.7.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/minimal": {
-          "version": "6.7.1",
-          "requires": {
-            "@sentry/hub": "6.7.1",
-            "@sentry/types": "6.7.1",
-            "tslib": "^1.9.3"
+            "@sentry/types": "8.33.1",
+            "@sentry/utils": "8.33.1"
           }
         },
         "@sentry/types": {
-          "version": "6.7.1"
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.33.1.tgz",
+          "integrity": "sha512-GjoAMvwtpIemoF/IiwZ7A60g4nQv3qwzR21GvJqDVUoKD0e8pv9OLX+HyXoUat4wEDGSuDUcUyUKD2G+od73QA=="
         },
         "@sentry/utils": {
-          "version": "6.7.1",
+          "version": "8.33.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.33.1.tgz",
+          "integrity": "sha512-uzuYpiiJuFY3N4WNHMBWUQX5oNv2t/TbG0OHRp3Rr7yeu+HSfD542TIp9/gMZ+G0Cxd8AmVO3wkKIFbk0TL4Qg==",
           "requires": {
-            "@sentry/types": "6.7.1",
-            "tslib": "^1.9.3"
+            "@sentry/types": "8.33.1"
           }
         }
       }
@@ -18515,8 +19655,9 @@
       }
     },
     "@types/connect": {
-      "version": "3.4.35",
-      "dev": true,
+      "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "requires": {
         "@types/node": "*"
       }
@@ -18658,6 +19799,14 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true
     },
+    "@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -18675,6 +19824,24 @@
     "@types/parse-json": {
       "version": "4.0.0",
       "dev": true
+    },
+    "@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "requires": {
+        "@types/pg": "*"
+      }
     },
     "@types/plist": {
       "version": "3.0.5",
@@ -18752,6 +19919,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
     },
     "@types/sockjs": {
       "version": "0.3.33",
@@ -19135,7 +20307,6 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
       "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
       "requires": {}
     },
     "acorn-jsx": {
@@ -19918,13 +21089,6 @@
       "dev": true,
       "requires": {}
     },
-    "bs-logger": {
-      "version": "0.2.6",
-      "dev": true,
-      "requires": {
-        "fast-json-stable-stringify": "2.x"
-      }
-    },
     "bser": {
       "version": "2.1.1",
       "dev": true,
@@ -20213,8 +21377,7 @@
       }
     },
     "cjs-module-lexer": {
-      "version": "1.2.2",
-      "dev": true
+      "version": "1.2.2"
     },
     "clean-css": {
       "version": "5.3.2",
@@ -20495,12 +21658,6 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
           "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
           "dev": true
-        },
-        "typescript": {
-          "version": "5.5.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-          "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-          "dev": true
         }
       }
     },
@@ -20532,9 +21689,6 @@
     "convert-source-map": {
       "version": "1.9.0",
       "dev": true
-    },
-    "cookie": {
-      "version": "0.4.2"
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -20869,9 +22023,11 @@
       }
     },
     "debug": {
-      "version": "4.3.4",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decimal.js": {
@@ -20922,8 +22078,7 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.3.1",
-      "dev": true
+      "version": "4.3.1"
     },
     "default-gateway": {
       "version": "6.0.3",
@@ -22182,9 +23337,9 @@
       }
     },
     "express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
@@ -22192,7 +23347,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -22225,9 +23380,9 @@
           "dev": true
         },
         "cookie": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-          "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+          "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
           "dev": true
         },
         "debug": {
@@ -23136,6 +24291,17 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-in-the-middle": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.11.2.tgz",
+      "integrity": "sha512-gK6Rr6EykBcc6cVWRSBR5TWf8nn6hZMYSRYqCcHa0l0d1fPK7JSYo6+Mlmck76jIX9aL/IZ71c06U2VpFwl1zA==",
+      "requires": {
+        "acorn": "^8.8.2",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
     "import-local": {
       "version": "3.1.0",
       "dev": true,
@@ -23260,10 +24426,11 @@
       }
     },
     "is-core-module": {
-      "version": "2.12.1",
-      "dev": true,
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
       }
     },
     "is-date-object": {
@@ -24504,9 +25671,6 @@
     "lowercase-keys": {
       "version": "2.0.0"
     },
-    "lru_map": {
-      "version": "0.3.3"
-    },
     "lru-cache": {
       "version": "6.0.0",
       "requires": {
@@ -24782,6 +25946,11 @@
       "version": "1.1.0",
       "requires": {}
     },
+    "module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+    },
     "moo": {
       "version": "0.5.2",
       "dev": true
@@ -24791,7 +25960,9 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.2"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -25246,8 +26417,7 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.7",
-      "dev": true
+      "version": "1.0.7"
     },
     "path-scurry": {
       "version": "1.11.1",
@@ -25305,6 +26475,28 @@
     "performance-now": {
       "version": "2.1.0",
       "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-protocol": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
+      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
     },
     "picocolors": {
       "version": "1.0.0",
@@ -25695,6 +26887,29 @@
       "version": "4.2.0",
       "dev": true
     },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "dev": true
@@ -26077,15 +27292,26 @@
     "require-from-string": {
       "version": "2.0.2"
     },
+    "require-in-the-middle": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz",
+      "integrity": "sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==",
+      "requires": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      }
+    },
     "requires-port": {
       "version": "1.0.0",
       "dev": true
     },
     "resolve": {
-      "version": "1.22.2",
-      "dev": true,
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -26349,12 +27575,6 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
           "dev": true
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
         }
       }
     },
@@ -26497,6 +27717,11 @@
     "shell-quote": {
       "version": "1.8.1",
       "dev": true
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "side-channel": {
       "version": "1.0.6",
@@ -26888,8 +28113,7 @@
       }
     },
     "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "svgo": {
       "version": "2.8.0",
@@ -27167,20 +28391,6 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "ts-jest": {
-      "version": "27.1.5",
-      "dev": true,
-      "requires": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^27.0.0",
-        "json5": "2.x",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "20.x"
-      }
-    },
     "ts-loader": {
       "version": "9.4.3",
       "dev": true,
@@ -27290,9 +28500,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="
     },
     "ua-parser-js": {
       "version": "1.0.37",

--- a/package.json
+++ b/package.json
@@ -242,9 +242,8 @@
     "sass-loader": "^12.2.0",
     "style-loader": "^3.3.0",
     "terser-webpack-plugin": "^5.2.4",
-    "ts-jest": "^27.0.5",
     "ts-loader": "^9.2.6",
-    "typescript": "^4.9.5",
+    "typescript": "^5.6.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.58.2",
     "webpack-bundle-analyzer": "^4.5.0",
@@ -255,10 +254,10 @@
   "dependencies": {
     "@devicefarmer/adbkit": "^3.2.6",
     "@electron/remote": "^2.1.2",
-    "@requestly/requestly-core": "^1.0.4",
+    "@requestly/requestly-core": "^1.0.5",
     "@requestly/requestly-proxy": "^1.3.2",
     "@sentry/browser": "^6.13.3",
-    "@sentry/electron": "^2.5.4",
+    "@sentry/electron": "^5.6.0",
     "address": "^2.0.3",
     "assert": "^2.0.0",
     "async": "^3.2.1",
@@ -306,8 +305,8 @@
     "yargs": "^17.2.1"
   },
   "devEngines": {
-    "node": ">=14.x",
-    "npm": ">=7.x"
+    "node": ">=20.x",
+    "npm": ">=9.x"
   },
   "browserslist": [],
   "prettier": {

--- a/src/main/actions/startBackgroundProcess.js
+++ b/src/main/actions/startBackgroundProcess.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { enable as enableWebContents } from "@electron/remote/main";
 /** Babel */
 require("core-js/stable");

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable */
 /* eslint global-require: off, no-console: off, promise/always-return: off */
 
 /**
@@ -277,7 +277,6 @@ const createWindow = async () => {
         case 0:
           // Set flag to check next iteration
           trackEventViaWebApp(webAppWindow, EVENTS.QUIT_APP)
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
           global.isQuitActionConfirmed = true;
           // Calling app.quit() would again invoke this function

--- a/src/packages/rq_proxy/ssl-proxying/ssl-proxying-manager.ts
+++ b/src/packages/rq_proxy/ssl-proxying/ssl-proxying-manager.ts
@@ -1,86 +1,86 @@
-import { ISource, SSLProxyingJsonObj } from "lib/storage/types/ssl-proxying";
-import BaseConfigFetcher from "renderer/lib/proxy-interface/base";
-// TODO: @sahil fix this by adding type.d.ts file
-//@ts-ignore
-import { RULE_PROCESSOR } from "@requestly/requestly-core";
+// import { ISource, SSLProxyingJsonObj } from "lib/storage/types/ssl-proxying";
+// import BaseConfigFetcher from "renderer/lib/proxy-interface/base";
+// // TODO: @sahil fix this by adding type.d.ts file
+// //@ts-ignore
+// import { RULE_PROCESSOR } from "@requestly/requestly-core";
 
-class SSLProxyingManager {
-  configFetcher: BaseConfigFetcher;
+// class SSLProxyingManager {
+//   configFetcher: BaseConfigFetcher;
 
-  constructor(configFetcher: BaseConfigFetcher) {
-    this.configFetcher = configFetcher;
-  }
+//   constructor(configFetcher: BaseConfigFetcher) {
+//     this.configFetcher = configFetcher;
+//   }
 
-  isSslProxyingActive = (urlOrigin: string): boolean => {
-    const config: SSLProxyingJsonObj = this.configFetcher.getConfig();
+//   isSslProxyingActive = (urlOrigin: string): boolean => {
+//     const config: SSLProxyingJsonObj = this.configFetcher.getConfig();
 
-    if (config.enabledAll === false) {
-      const inclusionListSuccess: boolean = this.checkStatusWithInclusionList(
-        config,
-        urlOrigin
-      );
-      if (inclusionListSuccess) {
-        console.log(`${urlOrigin} inclusion List`);
-        return true;
-      }
+//     if (config.enabledAll === false) {
+//       const inclusionListSuccess: boolean = this.checkStatusWithInclusionList(
+//         config,
+//         urlOrigin
+//       );
+//       if (inclusionListSuccess) {
+//         console.log(`${urlOrigin} inclusion List`);
+//         return true;
+//       }
 
-      return false;
-    } else {
-      const exclusionListSuccess: boolean = this.checkStatusWithExclusionList(
-        config,
-        urlOrigin
-      );
-      if (exclusionListSuccess) {
-        console.log(`${urlOrigin} exclusion List`);
-        return false;
-      }
+//       return false;
+//     } else {
+//       const exclusionListSuccess: boolean = this.checkStatusWithExclusionList(
+//         config,
+//         urlOrigin
+//       );
+//       if (exclusionListSuccess) {
+//         console.log(`${urlOrigin} exclusion List`);
+//         return false;
+//       }
 
-      return true;
-    }
-  };
+//       return true;
+//     }
+//   };
 
-  checkStatusWithInclusionList = (
-    config: SSLProxyingJsonObj,
-    urlOrigin: string
-  ): boolean => {
-    const inclusionListSources: ISource[] = Object.values(
-      config.inclusionList || {}
-    );
-    return this.checkStatusWithList(inclusionListSources, urlOrigin);
-  };
+//   checkStatusWithInclusionList = (
+//     config: SSLProxyingJsonObj,
+//     urlOrigin: string
+//   ): boolean => {
+//     const inclusionListSources: ISource[] = Object.values(
+//       config.inclusionList || {}
+//     );
+//     return this.checkStatusWithList(inclusionListSources, urlOrigin);
+//   };
 
-  checkStatusWithExclusionList = (
-    config: SSLProxyingJsonObj,
-    urlOrigin: string
-  ): boolean => {
-    const exclusionListSources: ISource[] = Object.values(
-      config.exclusionList || {}
-    );
-    return this.checkStatusWithList(exclusionListSources, urlOrigin);
-  };
+//   checkStatusWithExclusionList = (
+//     config: SSLProxyingJsonObj,
+//     urlOrigin: string
+//   ): boolean => {
+//     const exclusionListSources: ISource[] = Object.values(
+//       config.exclusionList || {}
+//     );
+//     return this.checkStatusWithList(exclusionListSources, urlOrigin);
+//   };
 
-  checkStatusWithList = (
-    sourceObjs: ISource[] = [],
-    urlOrigin: string = ""
-  ): boolean => {
-    return sourceObjs.some((sourceObj) =>
-      this.checkStatusForSource(sourceObj, urlOrigin)
-    );
-  };
+//   checkStatusWithList = (
+//     sourceObjs: ISource[] = [],
+//     urlOrigin: string = ""
+//   ): boolean => {
+//     return sourceObjs.some((sourceObj) =>
+//       this.checkStatusForSource(sourceObj, urlOrigin)
+//     );
+//   };
 
-  checkStatusForSource = (
-    sourceObject: ISource,
-    urlOrigin: string
-  ): boolean => {
-    const result = RULE_PROCESSOR.RuleMatcher.matchUrlWithRuleSource(
-      sourceObject,
-      urlOrigin
-    );
-    if (result === "") {
-      return true;
-    }
-    return false;
-  };
-}
+//   checkStatusForSource = (
+//     sourceObject: ISource,
+//     urlOrigin: string
+//   ): boolean => {
+//     const result = RULE_PROCESSOR.RuleMatcher.matchUrlWithRuleSource(
+//       sourceObject,
+//       urlOrigin
+//     );
+//     if (result === "") {
+//       return true;
+//     }
+//     return false;
+//   };
+// }
 
-export default SSLProxyingManager;
+// export default SSLProxyingManager;

--- a/src/renderer/actions/apps/mobile/adb-commands.ts
+++ b/src/renderer/actions/apps/mobile/adb-commands.ts
@@ -51,8 +51,8 @@ export async function hasCertInstalled(
     // Wait until it's clear that the read is successful
     const data = await new Promise<Buffer>((resolve, reject) => {
       // eslint-disable-next-line no-shadow
-      const data: Buffer[] = [];
-      certStream.on("data", (d: Buffer) => data.push(d));
+      const data: Uint8Array[] = [];
+      certStream.on("data", (d: Uint8Array) => data.push(d));
       certStream.on("end", () => resolve(Buffer.concat(data)));
 
       certStream.on("error", reject);

--- a/src/renderer/actions/initEventHandlers.js
+++ b/src/renderer/actions/initEventHandlers.js
@@ -2,16 +2,11 @@
 import "core-js/stable";
 import "regenerator-runtime/runtime";
 // CORE
-import { ipcMain, ipcRenderer, shell } from "electron";
+import { ipcRenderer, shell } from "electron";
 // ACTION
 import startProxyServer from "./proxy/startProxyServer";
 import getProxyConfig from "./proxy/getProxyConfig";
-import {
-  areAppsActivatable,
-  activateApp,
-  deactivateApp,
-  isAppActivatable,
-} from "./apps";
+import { activateApp, deactivateApp, isAppActivatable } from "./apps";
 import saveRootCert from "./saveRootCert";
 // STATE MANAGEMENT
 import { setState } from "./stateManagement";

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -20,4 +20,4 @@ initGroupsCache();
 initEventHandlers();
 initAppManager();
 
-import "../utils/sentryInit";
+// import "../utils/sentryInit";

--- a/src/utils/sentryInit.js
+++ b/src/utils/sentryInit.js
@@ -2,8 +2,8 @@ const preferenceManager = require("../renderer/utils/userPreferencesManager");
 const isMain = process.type === "browser";
 
 const { init } = isMain
-  ? require("@sentry/electron/dist/main")
-  : require("@sentry/electron/dist/renderer");
+  ? require("@sentry/electron/main")
+  : require("@sentry/electron/renderer");
 
 let isErrorTrackingEnabled;
 


### PR DESCRIPTION
- sentry init removed from renderer
- adb scripts had some Buffer to UInt8Array casting that was not working, needs to be tested
- added `eslint-disable` to `main.ts` to avoid annoying linter bugs
- updated vulnerable packages, and removed unused ones.
- updated requestly-core version - https://github.com/requestly/requestly/pull/2222