### PR TITLE
track terminal helper server connected

### DIFF
--- a/src/main/events.js
+++ b/src/main/events.js
@@ -245,6 +245,10 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
       return "err:NOT FOUND";
     }
   });
+
+  ipcMain.handle("helper-server-hit", () => {
+    webAppWindow.send("helper-server-hit");
+  });
 };
 
 export const registerMainProcessCommonEvents = () => {

--- a/src/renderer/actions/startHelperServer.js
+++ b/src/renderer/actions/startHelperServer.js
@@ -1,8 +1,13 @@
+import { ipcRenderer } from "electron";
 import { staticConfig } from "../config";
 
 const http = require("http");
 
 const pemPath = staticConfig.ROOT_CERT_PATH;
+
+function trackHelperServerHit() {
+  ipcRenderer.invoke("helper-server-hit");
+}
 
 const getShellScript = (port) => `
     export http_proxy="http://127.0.0.1:${port}"
@@ -42,6 +47,7 @@ const startHelperServer = async (helperServerPort) => {
       if (req.url === "/tpsetup") {
         const shellScript = getShellScript(window.proxy.httpPort);
         // const shellScript = `export http_proxy="http://127.0.0.1:${window.proxy.httpPort}"`
+        trackHelperServerHit();
         res.writeHead(200, { "Content-Type": "text/x-shellscript" });
         res.write(shellScript);
         res.end();

--- a/src/renderer/actions/startHelperServer.js
+++ b/src/renderer/actions/startHelperServer.js
@@ -1,7 +1,8 @@
 import { staticConfig } from "../config";
 
-var http = require("http");
-const pem_path = staticConfig.ROOT_CERT_PATH;
+const http = require("http");
+
+const pemPath = staticConfig.ROOT_CERT_PATH;
 
 const getShellScript = (port) => `
     export http_proxy="http://127.0.0.1:${port}"
@@ -13,13 +14,13 @@ const getShellScript = (port) => `
     export npm_config_proxy="http://127.0.0.1:${port}"
     export npm_config_https_proxy="http://127.0.0.1:${port}"
     export GOPROXY="http://127.0.0.1:${port}"
-    export SSL_CERT_FILE="${pem_path}"
-    export NODE_EXTRA_CA_CERTS="${pem_path}"
-    export REQUESTS_CA_BUNDLE="${pem_path}"
-    export PERL_LWP_SSL_CA_FILE="${pem_path}"
-    export GIT_SSL_CAINFO="${pem_path}"
-    export CARGO_HTTP_CAINFO="${pem_path}"
-    export CURL_CA_BUNDLE="${pem_path}"
+    export SSL_CERT_FILE="${pemPath}"
+    export NODE_EXTRA_CA_CERTS="${pemPath}"
+    export REQUESTS_CA_BUNDLE="${pemPath}"
+    export PERL_LWP_SSL_CA_FILE="${pemPath}"
+    export GIT_SSL_CAINFO="${pemPath}"
+    export CARGO_HTTP_CAINFO="${pemPath}"
+    export CURL_CA_BUNDLE="${pemPath}"
     if command -v winpty >/dev/null 2>&1; then
         # Work around for winpty's hijacking of certain commands
         alias php=php
@@ -35,10 +36,10 @@ const getShellScript = (port) => `
 
 const startHelperServer = async (helperServerPort) => {
   return new Promise((resolve) => {
-    var server = http.createServer(function (req, res) {
-      //create web server
+    const server = http.createServer((req, res) => {
+      // create web server
       console.log(window.proxy.httpPort);
-      if (req.url == "/tpsetup") {
+      if (req.url === "/tpsetup") {
         const shellScript = getShellScript(window.proxy.httpPort);
         // const shellScript = `export http_proxy="http://127.0.0.1:${window.proxy.httpPort}"`
         res.writeHead(200, { "Content-Type": "text/x-shellscript" });


### PR DESCRIPTION
We can't know for sure, but for now we are assuming if someone hits the helper server to get the required scripts, then they eventually get their terminal connected to Requestly

only [the last commit](https://github.com/requestly/requestly-desktop-app/pull/118/commits/6c65c7fa123d161c8b50d24409a0c50a0dee584d) is relevant, the rest is just cleanup.