### PR TITLE
feat: setup for any RPC Service Over IPC

### DIFF
--- a/src/main/actions/setupIPCForwarding.js
+++ b/src/main/actions/setupIPCForwarding.js
@@ -28,4 +28,10 @@ export const setupIPCForwardingToWebApp = (webAppWindow) => {
       });
     }
   );
+
+  ipcMain.on("send-from-background-to-webapp", (event, incomingData) => {
+    const { payload, channel } = incomingData;
+    console.log("Sending to webapp", channel, payload);
+    webAppWindow.webContents.send(channel, payload);
+  });
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -29,6 +29,7 @@ import { trackEventViaWebApp } from "./actions/events";
 import EVENTS from "./actions/events/constants";
 import fs from "fs";
 import logger from "../utils/logger";
+import { setupIPCForwardingToWebApp } from "./actions/setupIPCForwarding";
 
 // Init remote so that it could be consumed in renderer
 const remote = require("@electron/remote/main");
@@ -430,6 +431,7 @@ app.on("ready", () => {
     // Create Renderer Window
     await createWindow();
     // Register Remaining IPC Events that involve browser windows
+    setupIPCForwardingToWebApp(webAppWindow);
     registerMainProcessEventsForWebAppWindow(webAppWindow);
     registerMainProcessCommonEvents();
 

--- a/src/renderer/lib/RPCServiceOverIPC.ts
+++ b/src/renderer/lib/RPCServiceOverIPC.ts
@@ -1,0 +1,50 @@
+import { ipcRenderer } from "electron";
+
+/**
+ * Used to create a RPC like service in the Background process.
+ * Has a corresponding Adapter class in the webapp repository.
+ * --------------------------------
+ * - Expects each RPC method to be exposed individually using `exposeMethodOverIPC`.
+ * - Requires Arguments and Responses of those methods to be serializable. (limitation imposed by electron IPC)
+ * - Currently only allows one generic fire-and-forget event channel for the service to send events to the webapp -> relayed over "send-from-background-to-webapp" channel.
+ */
+export class RPCServiceOverIPC {
+  private RPC_CHANNEL_PREFIX: string;
+
+  private LIVE_EVENTS_CHANNEL: string;
+
+  constructor(serviceName: string) {
+    this.RPC_CHANNEL_PREFIX = `${serviceName}-`;
+    this.LIVE_EVENTS_CHANNEL = `SERVICE-${serviceName}-LIVE-EVENTS`;
+  }
+
+  private generateChannelNameForMethod(method: Function) {
+    return `${this.RPC_CHANNEL_PREFIX}${method.name}`;
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  protected exposeMethodOverIPC(method: (..._args: any[]) => Promise<any>) {
+    const channelName = this.generateChannelNameForMethod(method);
+    ipcRenderer.on(channelName, async (_event, args) => {
+      try {
+        const result = await method(args);
+        ipcRenderer.send(`reply-${channelName}`, {
+          success: true,
+          data: result,
+        });
+      } catch (error: any) {
+        ipcRenderer.send(`reply-${channelName}`, {
+          success: false,
+          data: error.message,
+        });
+      }
+    });
+  }
+
+  protected sendServiceEvent(event: any) {
+    return ipcRenderer.send("send-from-background-to-webapp", {
+      channel: this.LIVE_EVENTS_CHANNEL,
+      payload: event,
+    });
+  }
+}

--- a/src/renderer/lib/RPCServiceOverIPC.ts
+++ b/src/renderer/lib/RPCServiceOverIPC.ts
@@ -18,16 +18,19 @@ export class RPCServiceOverIPC {
     this.LIVE_EVENTS_CHANNEL = `SERVICE-${serviceName}-LIVE-EVENTS`;
   }
 
-  private generateChannelNameForMethod(method: Function) {
-    return `${this.RPC_CHANNEL_PREFIX}${method.name}`;
+  private generateChannelNameForMethod(methodName: string) {
+    return `${this.RPC_CHANNEL_PREFIX}${methodName}`;
   }
 
-  // eslint-disable-next-line no-unused-vars
-  protected exposeMethodOverIPC(method: (..._args: any[]) => Promise<any>) {
-    const channelName = this.generateChannelNameForMethod(method);
+  protected exposeMethodOverIPC(
+    exposedMethodName: string,
+    // eslint-disable-next-line no-unused-vars
+    method: (..._args: any[]) => Promise<any>
+  ) {
+    const channelName = this.generateChannelNameForMethod(exposedMethodName);
     ipcRenderer.on(channelName, async (_event, args) => {
       try {
-        const result = await method(args);
+        const result = await method(...args);
         ipcRenderer.send(`reply-${channelName}`, {
           success: true,
           data: result,


### PR DESCRIPTION
Built for making it easy to bridge the local sync backend with the consumers in the web app.
Will be consumed via the corresponding adapter in the webapp - https://github.com/requestly/requestly/pull/2677