### PR TITLE
chore: bump version to v2025.04.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "2.0.0",
+  "version": "2025.04.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "2.0.0",
+      "version": "2025.04.11",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "2.0.0",
+  "version": "2025.04.11",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "2.0.0",
+  "version": "2025.04.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "2.0.0",
+      "version": "2025.04.11",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "2.0.0",
+  "version": "2025.04.11",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
_Going forward versions would be vYYYY.MM.DD corresponding to date of release_
- feat: local workspaces