### PR TITLE
fix: new version semantics to follow semver rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "2025.04.13",
+  "version": "25.4.13",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "2025.04.13",
+  "version": "25.4.13",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
Having leading zeros in any part of the version was prompts notary tool to create a new tag and release against that. 
Because [this goes against semver rules](https://semver.org/#spec-item-2) that are _probably_ being applied [here](https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/src/util/normalizePackageData.ts#L148)

So updating the versioning to now resemble the one used for the browser extension 
_v2025.04.13_ -> _v25.4.13_