### PR TITLE
chore: bump version to v25.5.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "requestly",
-  "version": "25.5.12",
+  "version": "25.5.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "25.5.12",
+      "version": "25.5.19",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@devicefarmer/adbkit": "^3.2.6",
         "@electron/remote": "^2.1.2",
         "@requestly/requestly-core": "^1.1.0",
-        "@requestly/requestly-proxy": "^1.3.5",
+        "@requestly/requestly-proxy": "^1.3.7",
         "@sentry/browser": "^8.34.0",
         "@sentry/electron": "^5.6.0",
         "@sinclair/typebox": "^0.34.25",
@@ -2462,9 +2462,10 @@
       "integrity": "sha512-uNWWfZvedkWVSj/NCcJREHhypzqbtJQ1SGykqBVbRoWCXwfptEhEjS2zG1hotFZN4QZtnmmZ6r2WSSRR7RGlkQ=="
     },
     "node_modules/@requestly/requestly-proxy": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.5.tgz",
-      "integrity": "sha512-GEleXIHGFebnQ+1uG364Sr5yNJrbVO5g1Lvd1VllWXpKUKVD5xgiw3adEza2Tit2f0wockuA2TqnW4v5mrVmqQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.7.tgz",
+      "integrity": "sha512-uI2k20OqlVabZ7sgSc9w9bFdvzqB57c2iQVXdpwelB9PAvFVm1A6olM4NkzXXBcVzAx2Qcb+qu+MPXHk5HxDnA==",
+      "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "^1.1.0",
         "@sentry/browser": "^8.33.1",
@@ -18827,9 +18828,9 @@
       "integrity": "sha512-uNWWfZvedkWVSj/NCcJREHhypzqbtJQ1SGykqBVbRoWCXwfptEhEjS2zG1hotFZN4QZtnmmZ6r2WSSRR7RGlkQ=="
     },
     "@requestly/requestly-proxy": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.5.tgz",
-      "integrity": "sha512-GEleXIHGFebnQ+1uG364Sr5yNJrbVO5g1Lvd1VllWXpKUKVD5xgiw3adEza2Tit2f0wockuA2TqnW4v5mrVmqQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.7.tgz",
+      "integrity": "sha512-uI2k20OqlVabZ7sgSc9w9bFdvzqB57c2iQVXdpwelB9PAvFVm1A6olM4NkzXXBcVzAx2Qcb+qu+MPXHk5HxDnA==",
       "requires": {
         "@requestly/requestly-core": "^1.1.0",
         "@sentry/browser": "^8.33.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "25.5.14",
+  "version": "25.5.19",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
@@ -257,7 +257,7 @@
     "@devicefarmer/adbkit": "^3.2.6",
     "@electron/remote": "^2.1.2",
     "@requestly/requestly-core": "^1.1.0",
-    "@requestly/requestly-proxy": "^1.3.6",
+    "@requestly/requestly-proxy": "^1.3.7",
     "@sentry/browser": "^8.34.0",
     "@sentry/electron": "^5.6.0",
     "@sinclair/typebox": "^0.34.25",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "25.5.12",
+  "version": "25.5.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "25.5.12",
+      "version": "25.5.19",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -734,15 +734,6 @@
       "version": "1.2.0",
       "license": "ISC"
     },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ini": {
       "version": "1.3.8",
       "license": "ISC"
@@ -1368,15 +1359,6 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -2324,11 +2306,6 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1"
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",
@@ -3362,11 +3339,6 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1"
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "25.5.14",
+  "version": "25.5.19",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
releasing:
- `serveWithoutRequest` for modify response with local file: 
    - Proxy changes: https://github.com/requestly/requestly-proxy/pull/59 
    - Corresponding UI: https://github.com/requestly/requestly/pull/3005
- Added new certificate authority to Designated Requirements https://github.com/requestly/requestly-desktop-app/pull/162
    - This _(and any releases beyond this)_ would hence be the intermediate releases for the Authority migration process for macOS