### PR TITLE
chore: bump version to v25.5.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "requestly",
-  "version": "25.5.25",
+  "version": "25.5.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "25.5.25",
+      "version": "25.5.30",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@devicefarmer/adbkit": "^3.2.6",
         "@electron/remote": "^2.1.2",
         "@requestly/requestly-core": "^1.1.0",
-        "@requestly/requestly-proxy": "^1.3.8",
+        "@requestly/requestly-proxy": "^1.3.10",
         "@sentry/browser": "^8.34.0",
         "@sentry/electron": "^5.6.0",
         "@sinclair/typebox": "^0.34.25",
@@ -2462,9 +2462,9 @@
       "integrity": "sha512-uNWWfZvedkWVSj/NCcJREHhypzqbtJQ1SGykqBVbRoWCXwfptEhEjS2zG1hotFZN4QZtnmmZ6r2WSSRR7RGlkQ=="
     },
     "node_modules/@requestly/requestly-proxy": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.8.tgz",
-      "integrity": "sha512-4tBgu1XjhKTBJ2FGb6laMDgYx5yTh8EIQ0iWquwQ0sA1Z52AJQBDuUUsgzRuzhWCrYPpwhFPeGV06JIoWHOF+A==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.10.tgz",
+      "integrity": "sha512-3nqYdRlzxi9xh4ZuS4TZY1KJS1xj+pEusC4rnAyEBvFnR+EJ2ER4RFWHBtcJzPixOmoYH++AArcyOuDYi4lexQ==",
       "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "^1.1.0",
@@ -18844,9 +18844,9 @@
       "integrity": "sha512-uNWWfZvedkWVSj/NCcJREHhypzqbtJQ1SGykqBVbRoWCXwfptEhEjS2zG1hotFZN4QZtnmmZ6r2WSSRR7RGlkQ=="
     },
     "@requestly/requestly-proxy": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.8.tgz",
-      "integrity": "sha512-4tBgu1XjhKTBJ2FGb6laMDgYx5yTh8EIQ0iWquwQ0sA1Z52AJQBDuUUsgzRuzhWCrYPpwhFPeGV06JIoWHOF+A==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.10.tgz",
+      "integrity": "sha512-3nqYdRlzxi9xh4ZuS4TZY1KJS1xj+pEusC4rnAyEBvFnR+EJ2ER4RFWHBtcJzPixOmoYH++AArcyOuDYi4lexQ==",
       "requires": {
         "@requestly/requestly-core": "^1.1.0",
         "@sentry/browser": "^8.33.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "25.5.25",
+  "version": "25.5.30",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
@@ -257,7 +257,7 @@
     "@devicefarmer/adbkit": "^3.2.6",
     "@electron/remote": "^2.1.2",
     "@requestly/requestly-core": "^1.1.0",
-    "@requestly/requestly-proxy": "^1.3.8",
+    "@requestly/requestly-proxy": "^1.3.10",
     "@sentry/browser": "^8.34.0",
     "@sentry/electron": "^5.6.0",
     "@sinclair/typebox": "^0.34.25",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "25.5.25",
+  "version": "25.5.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "25.5.25",
+      "version": "25.5.30",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -734,6 +734,15 @@
       "version": "1.2.0",
       "license": "ISC"
     },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ini": {
       "version": "1.3.8",
       "license": "ISC"
@@ -1359,6 +1368,15 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -2306,6 +2324,11 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1"
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",
@@ -3339,6 +3362,11 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1"
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "25.5.25",
+  "version": "25.5.30",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
upgrading to [latest version of requestly-proxy](https://github.com/requestly/requestly-proxy/pull/68). This rolls out the following:
- https://github.com/requestly/requestly-proxy/pull/62
- https://github.com/requestly/requestly-proxy/pull/64
- https://github.com/requestly/requestly-proxy/pull/67