### PR TITLE
chore: bump version to v25.7.21

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,13 @@ module.exports = {
     "no-await-in-loop": "off",
     "prettier/prettier": "off",
     "no-nested-ternary": "off",
+    "no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "25.7.9",
+  "version": "25.7.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "25.7.9",
+      "version": "25.7.21",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "25.7.9",
+  "version": "25.7.21",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "25.7.9",
+  "version": "25.7.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "25.7.9",
+      "version": "25.7.21",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "25.7.9",
+  "version": "25.7.21",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
- updates the eslint config to only warn on unused variables and allow them if starting with an underscore

Releases:
- https://github.com/requestly/requestly-desktop-app/pull/191