### PR TITLE
[ONCALL-125] chore: stop api client request to be proxied

### DIFF
--- a/src/main/actions/getProxiedAxios.ts
+++ b/src/main/actions/getProxiedAxios.ts
@@ -32,17 +32,25 @@ let proxyConfig: ProxyConfig;
 
 function createAxiosInstance(
   config: ProxyConfig,
+  enableRQProxy: boolean = false,
   addStoredCookies: boolean = false
 ): AxiosInstance {
-  const instance = axios.create({
-    proxy: false,
-    httpAgent: new HttpsProxyAgent(`http://${config.ip}:${config.port}`),
-    httpsAgent: new PatchedHttpsProxyAgent({
-      host: config.ip,
-      port: config.port,
-      ca: readFileSync(config.rootCertPath),
-    }),
-  });
+  let instance: AxiosInstance;
+  if (enableRQProxy) {
+    instance = axios.create({
+      proxy: false,
+      httpAgent: new HttpsProxyAgent(`http://${config.ip}:${config.port}`),
+      httpsAgent: new PatchedHttpsProxyAgent({
+        host: config.ip,
+        port: config.port,
+        ca: readFileSync(config.rootCertPath),
+      }),
+    });
+  } else {
+    instance = axios.create({
+      proxy: false,
+    });
+  }
 
   instance.interceptors.response.use(storeCookiesFromResponse);
   if (addStoredCookies) {
@@ -60,8 +68,8 @@ export const createOrUpdateAxiosInstance = (
   };
 
   try {
-    proxiedAxios = createAxiosInstance(proxyConfig);
-    proxiedAxiosWithSessionCookies = createAxiosInstance(proxyConfig, true);
+    proxiedAxios = createAxiosInstance(proxyConfig, false);
+    proxiedAxiosWithSessionCookies = createAxiosInstance(proxyConfig, false, true);
   } catch (error) {
     /* Do nothing */
     console.error("Error creating or updating Axios instance:", error);


### PR DESCRIPTION
Fixes: https://github.com/requestly/requestly-desktop-app/issues/215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional proxy support for network requests; when enabled, traffic is routed through a secure proxy for compatible environments.
  * Introduced a separate session-aware request path that preserves cookies, improving continuity across authenticated actions.
* **Refactor**
  * Streamlined network client creation and cookie handling to ensure consistent behavior across proxied and non-proxied requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->