### PR TITLE
chore: remove unnecessary permissions from setapp build

### DIFF
--- a/electron-builder-setapp.json
+++ b/electron-builder-setapp.json
@@ -68,7 +68,11 @@
             "com.setapp.DesktopClient.SetappAgent"
           ]
         }
-      }
+      },
+      "NSCameraUsageDescription": null,
+      "NSMicrophoneUsageDescription": null,
+      "NSBluetoothAlwaysUsageDescription": null,
+      "NSBluetoothPeripheralUsageDescription": null
     },
     "files": [
       "!**/.git/*",


### PR DESCRIPTION
bringing fixes from https://github.com/requestly/requestly-desktop-app/pull/209 to setapp builds as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS privacy permissions configuration to include camera, microphone, and Bluetooth settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->