### PR TITLE
fix: move setapp framework initialize to outside app.activate handler

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -473,11 +473,14 @@ app.on("window-all-closed", () => {
 app
   .whenReady()
   .then(() => {
+    if (process.env.IS_SETAPP_BUILD === "true") {
+      log.log("[SETAPP] build identified")
+      const setappFramework = require("@setapp/framework-wrapper");
+      setappFramework.SetappManager.shared.reportUsageEvent(setappFramework.SETAPP_USAGE_EVENT.USER_INTERACTION);
+      log.log("[SETAPP] integration complete")
+    }
+
     app.on("activate", () => {
-      if (process.env.IS_SETAPP_BUILD === "true") {
-        const setappFramework = require("@setapp/framework-wrapper");
-        setappFramework.SetappManager.shared.reportUsageEvent(setappFramework.SETAPP_USAGE_EVENT.USER_INTERACTION);
-      }
 
       // On macOS it's common to re-create a window in the app when the
       // dock icon is clicked and there are no other windows open.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Setapp integration initialization timing for affected builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->