### PR TITLE
chore: allow provisioning server to launch in sandboxed processes

### DIFF
--- a/assets/entitlements.mac.plist
+++ b/assets/entitlements.mac.plist
@@ -6,5 +6,9 @@
     <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+    <array>
+      <string>com.setapp.ProvisioningService</string>
+    </array>
   </dict>
 </plist>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS application entitlements configuration to enable additional system integration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->