### PR TITLE
fix: localhost resolution error

### DIFF
--- a/src/main/actions/getProxiedAxios.ts
+++ b/src/main/actions/getProxiedAxios.ts
@@ -6,6 +6,9 @@ import {
   addCookiesToRequest,
   storeCookiesFromResponse,
 } from "./cookiesHelpers";
+const dns = require("dns")
+import http from "http";
+import https from "https";
 
 class PatchedHttpsProxyAgent extends HttpsProxyAgent {
   ca: unknown;
@@ -47,8 +50,20 @@ function createAxiosInstance(
       }),
     });
   } else {
+    /* https://github.com/requestly/requestly-desktop-app/pull/227 */
+    const localhostIPv4Lookup = (hostname: any, options: any, callback: any) => {
+      if (hostname === 'localhost') {
+        dns.lookup(hostname, { ...options, family: 4 }, callback);
+      } else {
+        dns.lookup(hostname, options, callback);
+      }
+    };
+    const httpAgent = new http.Agent({ lookup: localhostIPv4Lookup });
+    const httpsAgent = new https.Agent({ lookup: localhostIPv4Lookup });
     instance = axios.create({
       proxy: false,
+      httpAgent,
+      httpsAgent,
     });
   }
 

--- a/src/main/actions/makeApiClientRequest.js
+++ b/src/main/actions/makeApiClientRequest.js
@@ -2,8 +2,6 @@ import getProxiedAxios from "./getProxiedAxios";
 import AdvancedFormData from "form-data";
 
 const fs = require("fs");
-const dns = require("dns")
-dns.setDefaultResultOrder('ipv4first');
 
 const makeApiClientRequest = async ({ apiRequest }) => {
   try {


### PR DESCRIPTION
- nodejs 17+ changed dns resolution to match the results returned from the os *[Ref](https://github.com/nodejs/node/pull/39793)*
- the `httpProxyAgent` *(that we recently removed - https://github.com/requestly/requestly-desktop-app/pull/214)* in the axios config was earlier managing the fallback to this and resolving through ipv4 for loopback addresses *[Ref](https://github.com/TooTallNate/proxy-agents/blob/main/packages/pac-resolver/src/ip.ts#L41-L61)*

Two ways to solve this could be:
  - change the dns result order from `verbatim` to   `ipv4first` to force ipv4 resolution for all cases. but this would impact all requests and not just loopback address. hence, this might have unexpected consequences
  - make a custom agent that handles this specifically

This PR proposes changes for the second approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed localhost connection resolution to ensure consistent IPv4 protocol usage, improving network reliability across different proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->