### PR TITLE
Revert "[ONCALL-125] chore: stop api client request to be proxied"

### DIFF
--- a/src/main/actions/getProxiedAxios.ts
+++ b/src/main/actions/getProxiedAxios.ts
@@ -32,25 +32,17 @@ let proxyConfig: ProxyConfig;
 
 function createAxiosInstance(
   config: ProxyConfig,
-  enableRQProxy: boolean = false,
   addStoredCookies: boolean = false
 ): AxiosInstance {
-  let instance: AxiosInstance;
-  if (enableRQProxy) {
-    instance = axios.create({
-      proxy: false,
-      httpAgent: new HttpsProxyAgent(`http://${config.ip}:${config.port}`),
-      httpsAgent: new PatchedHttpsProxyAgent({
-        host: config.ip,
-        port: config.port,
-        ca: readFileSync(config.rootCertPath),
-      }),
-    });
-  } else {
-    instance = axios.create({
-      proxy: false,
-    });
-  }
+  const instance = axios.create({
+    proxy: false,
+    httpAgent: new HttpsProxyAgent(`http://${config.ip}:${config.port}`),
+    httpsAgent: new PatchedHttpsProxyAgent({
+      host: config.ip,
+      port: config.port,
+      ca: readFileSync(config.rootCertPath),
+    }),
+  });
 
   instance.interceptors.response.use(storeCookiesFromResponse);
   if (addStoredCookies) {
@@ -68,8 +60,8 @@ export const createOrUpdateAxiosInstance = (
   };
 
   try {
-    proxiedAxios = createAxiosInstance(proxyConfig, false);
-    proxiedAxiosWithSessionCookies = createAxiosInstance(proxyConfig, false, true);
+    proxiedAxios = createAxiosInstance(proxyConfig);
+    proxiedAxiosWithSessionCookies = createAxiosInstance(proxyConfig, true);
   } catch (error) {
     /* Do nothing */
     console.error("Error creating or updating Axios instance:", error);


### PR DESCRIPTION
Reverts requestly/requestly-desktop-app#214

was causing issues with hitting localhost. Another potential fix has been raised here (with the explanation of the issue)
https://github.com/requestly/requestly-desktop-app/pull/227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal proxy configuration logic to streamline request handling and reduce code complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->