### PR TITLE
chore: bump version to v25.11.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "25.11.12",
+  "version": "25.11.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "25.11.12",
+      "version": "25.11.13",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -2543,6 +2543,7 @@
       "version": "1.3.12",
       "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.12.tgz",
       "integrity": "sha512-r4CHQ9jZRREI8ZndjrQMeC0sn6GA27PqBDnBtct7pm1LJ3nu4njikf2UUFHzSwkt48D2okERpU+KNY57pE+FcA==",
+      "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "1.1.1",
         "@sentry/browser": "^8.33.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "25.11.12",
+  "version": "25.11.13",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "25.11.12",
+  "version": "25.11.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "25.11.12",
+      "version": "25.11.13",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "25.11.12",
+  "version": "25.11.13",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
- reverts https://github.com/requestly/requestly-desktop-app/pull/214 via https://github.com/requestly/requestly-desktop-app/pull/228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version bump (25.11.12 → 25.11.13). No user-facing changes or new functionality included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->