### PR TITLE
feat:exclude error files(3746)

### DIFF
--- a/src/renderer/actions/local-sync/fs-manager.rpc-service.ts
+++ b/src/renderer/actions/local-sync/fs-manager.rpc-service.ts
@@ -151,6 +151,11 @@ export class FsManagerRPCService extends RPCServiceOverIPC {
       this.fsManager.createCollectionFromCompleteRecord.bind(this.fsManager)
     );
 
+    this.exposeMethodOverIPC(
+      "excludeFile",
+      this.fsManager.excludeFile.bind(this.fsManager)
+    );
+
     // hack
     await waitForInit();
   }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to Requestly. Adding details below will help us to merge your PR faster. -->

Closes issue: <!-- Link to Github issue -->  https://github.com/requestly/requestly/issues/3746

## 🎥 Demo Video:

<!-- 
📹 Please provide a video demonstration of your changes in action.
This helps reviewers understand the functionality and verify the implementation.

You can:
- Record a screen recording showing the feature/fix working
- Upload the video directly to this PR (drag & drop) or share a link (YouTube, Loom, etc.)
- For small UI changes, GIFs are also acceptable

If your changes are not user-facing (e.g., refactoring, build improvements), 
please explain why a video is not applicable.
-->

**Video/Demo:** <!-- Add your video link or upload here -->
Before : 
<img width="1440" height="900" alt="Screenshot 2025-11-22 at 7 03 44 PM" src="https://github.com/user-attachments/assets/dbbbd5ac-9637-42e4-8174-140ccef68cdf" />

After : 

https://github.com/user-attachments/assets/7e46cab2-7f84-49a1-8096-ffacb52c3ef6



## 📜 Summary of changes:
 📝 Overview

  Implemented a new feature that allows users to exclude errored files directly from
  the UI. When a workspace contains invalid/unsupported files, users can now click an
   "Exclude" button to permanently ignore these files in future workspace scans.

  ---
  ✨ What's New

  User-Facing Features

  - ✅ Added "Exclude" button (eye-off icon) next to each errored file in the sidebar
  - ✅ One-click exclusion of problematic files from workspace scanning
  - ✅ Excluded files are stored in requestly.json and persist across app restarts
  - ✅ Automatic workspace refresh after exclusion
  - ✅ Success/error toast notifications for user feedback

  ---
  🏗️ Architecture

  The implementation follows the existing architecture pattern and leverages the
  already-present exclusion mechanism:

  UI (React) → Repository → Adapter → IPC → Desktop App (FsManager) → requestly.json

  How It Works

  1. User clicks "Exclude" on an errored file
  2. File path is added to the exclude array in workspace's requestly.json
  3. FsIgnoreManager is reloaded with updated exclusion patterns
  4. Workspace automatically refreshes
  5. Excluded file no longer appears in error files list

  ---
  📁 Files Changed

  Desktop App (requestly-desktop-app)

  1. Core Logic

  - src/renderer/actions/local-sync/fs-manager.ts
    - Added excludeFile(filePath) method (lines 128-210)
    - Validates file is within workspace root
    - Converts absolute path to relative path
    - Adds to requestly.json exclude array (avoids duplicates)
    - Automatically reloads FsIgnoreManager

  2. IPC Service

  - src/renderer/actions/local-sync/fs-manager.rpc-service.ts
    - Exposed excludeFile method via RPC (lines 154-157)
    - IPC channel: local_sync: ${workspacePath}-excludeFile

  ---
  Webapp (requestly/app)

  1. Adapter Layer

  - src/services/fsManagerServiceAdapter.ts
    - Added excludeFile(filePath) method (lines 179-182)
    - Decorated with @FsErrorHandler for error handling

  2. Repository Interface

  - src/features/apiClient/helpers/modules/sync/interfaces.ts
    - Added excludeErrorFile(filePath) to ApiClientRecordsInterface (line 87)

  3. Repository Implementation

  - src/features/apiClient/helpers/modules/sync/local/services/LocalApiClientRecordsS
  ync.ts
    - Implemented excludeErrorFile() method (lines 595-614)
    - Calls adapter's excludeFile() method

  4. UI Component

  - src/features/apiClient/screens/apiClient/components/sidebar/components/ErrorFiles
  List/ErrorFileslist.tsx
    - Imported MdVisibilityOff icon (line 5)
    - Added excludeErrorFile prop to ErrorFileItem (line 109)
    - Added exclude button with tooltip (lines 119-121)
    - Implemented handleExcludeErrorFile handler (lines 185-205)
    - Triggers forceRefreshRecords/Environments after exclusion

  ---

  Exclusion Mechanism

  - Uses existing FsIgnoreManager class
  - Leverages ignore npm package (gitignore-style patterns)
  - Supports:
    - Exact file matches: "file.txt"
    - Wildcards: "*.log", "**/*.tmp"
    - Folder patterns: "node_modules", "dist/**"

  Filtering Flow

  1. getAllRecords() → parseFolder()
  2. parseFolder() → sanitizeFsResourceList(..., this.fsIgnoreManager)
  3. sanitizeFsResourceList() → fsIgnoreManager.checkShouldIgnore(path)
  4. Excluded files are filtered out before parsing
  5. Only non-excluded files can appear in erroredRecords

  ---
  ✅ Testing Checklist

  - Desktop app compiles without errors
  - Webapp compiles without errors
  - Exclude button appears for each errored file
  - Clicking exclude adds correct path to requestly.json
  - No first character missing in saved paths
  - No trailing slashes in saved paths
  - Excluded file disappears after workspace refresh
  - Success toast notification appears
  - Error handling works for invalid paths
  - Works for both API and Environment error files
  - Exclusions persist across app restarts
  - Duplicate exclusions are prevented

  ---
  🎨 UI Changes

  Before: Errored files only had "Edit" and "Delete" buttons

  After: Errored files now have "Edit", "Exclude" (eye-off icon), and "Delete"
  buttons

  ---
  📊 Impact

  - User Experience: Users can now manage problematic files without manually editing
  requestly.json
  - Backwards Compatible: No breaking changes, works with existing workspaces
  - Performance: No performance impact, uses existing exclusion infrastructure
  - Maintainability: Follows existing code patterns and architecture

  ---
  🔗 Related


  - Builds on existing FsIgnoreManager infrastructure
  - No new dependencies added
  - No schema changes (uses existing requestly.json structure)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file exclusion capability to exclude specific files from workspace synchronization, with changes automatically persisted to configuration and applied immediately upon workspace reload.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->