### PR TITLE
[ENGG-5014] fix: Add a retry mechanism for workspace deletion to handle transient EPERM scandir

### DIFF
--- a/src/renderer/actions/local-sync/fs-utils.ts
+++ b/src/renderer/actions/local-sync/fs-utils.ts
@@ -805,7 +805,7 @@ export async function removeWorkspace(
           force: true,
         });
       } catch (e1: any) {
-        // Retry once after ~100ms to handle transient EPERM during scandir
+        // Retry once after ~100ms to handle transient fs errors (e.g. EPERM during scandir)
         await delay(100);
         try {
           await FsService.rm(workspaceToRemove.path, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace removal reliability by adding a one-time automatic retry after a brief delay for transient filesystem errors (e.g., temporary permission or access issues). If the retry also fails, the original error is returned. This increases success rates for workspace cleanup while preserving existing error behavior on persistent failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->