### PR TITLE
chore: bump requestly-proxy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "@devicefarmer/adbkit": "^3.2.6",
     "@electron/remote": "^2.1.2",
     "@requestly/requestly-core": "1.1.1",
-    "@requestly/requestly-proxy": "1.3.12",
+    "@requestly/requestly-proxy": "1.3.13",
     "@sentry/browser": "^8.34.0",
     "@sentry/electron": "^5.6.0",
     "@sinclair/typebox": "^0.34.25",


### PR DESCRIPTION
Bump to v1.3.13
https://github.com/requestly/requestly-proxy/releases/tag/v1.3.13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core proxy dependency to a newer version for improved stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->