### PR TITLE
[ONCALL-264] fix: axios double stringifying request body string when sent with application/json

### DIFF
--- a/src/main/actions/makeApiClientRequest.js
+++ b/src/main/actions/makeApiClientRequest.js
@@ -81,13 +81,9 @@ const makeApiClientRequest = async ({ apiRequest }) => {
         (key) => key.toLowerCase() === "content-type"
       );
 
-      if (contentTypeHeader) {
-        return headers[contentTypeHeader]
-          ?.toLowerCase()
-          ?.includes("application/json");
-      }
-
-      return apiRequest.contentType === "application/json";
+      return headers[contentTypeHeader]
+        ?.toLowerCase()
+        ?.includes("application/json");
     })();
 
     let transformRequest;


### PR DESCRIPTION
In application/json requests when the body string is not a valid json axios automatically stringifies it. 

Refer axios' implementation: default [transformRequest](https://github.com/axios/axios/blob/v1.x/lib/defaults/index.js#L42-L98) and [safelyStringify](https://github.com/axios/axios/blob/v1.x/lib/defaults/index.js#L21-L34).

As this is core of our API client, we want the users to have control over what data format they need to send instead of implicitly transforming the data.

## Solution

This PR bypasses axios' default transformation when content type is `application/json` and allows the data to be sent as is, in raw form, if request data is not a valid JSON string.

## Test cases

1. Send string body with a `application/json` content type. The body shouldn't reach the server double stringified.
2. Send string body by explicitly setting the content type header to `application/json`. The body should not reach the server stringified.
3. Test string body with `text/plain` content type. No behavior changes expected
4. No behaviour change is expected when content-type is not `application/json`. Everything should work as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable multipart/form-data handling: skips non-file entries and consistently appends files.
  * Consistent content-type detection to respect headers case-insensitively.
  * Smarter JSON request handling: detects JSON content type and avoids double-stringifying bodies that are already strings or invalid JSON.
  * No changes to public API signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->