### PR TITLE
fix: distutils missing in windows ci

### DIFF
--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -20,7 +20,7 @@ jobs:
       # APPLE_ID: ${{ secrets.apple_id }}
       # APPLE_ID_PASS: ${{ secrets.apple_id_pass }}
 
-    if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production' || github.ref == 'refs/heads/fix-distutils-windows-ci'
+    if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
     runs-on: ${{ github.event.inputs.build_type }}
 
     steps:


### PR DESCRIPTION
the default version on the `windows-latest` machine on github ci seems to have upgraded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows desktop app build process with enhanced dependency handling during builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->