### PR TITLE
fix: remove proxy for api client requests & resolve localhost requests

### DIFF
--- a/src/main/actions/getProxiedAxios.ts
+++ b/src/main/actions/getProxiedAxios.ts
@@ -104,7 +104,7 @@ function createAxiosInstance(
       const url = new URL(requestUrl);
       const { hostname, port: urlPort, protocol } = url;
 
-      if (hostname === "localhost") { 
+      if (hostname === "localhost" || hostname === LOCAL_IPV6 || hostname === LOCAL_IPV4) { 
         // convert string port to integer
         const port = urlPort ? parseInt(urlPort, 10) : protocol === "https:" ? 443 : 80;
 


### PR DESCRIPTION
URL Port was required for customLookup, hence used `Interceptors` of axios API
check doc for reference https://axios-http.com/docs/interceptors

For non-localhost requests, axios default dns resolution will internally  it, we do not custom lookup for them

How to test
1. test it on localhost:3000
2. run on the local endpoints of the emulator run
3. any dev server
4. hosted api endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 localhost connectivity with automatic IPv4 fallback support
  * Enhanced dynamic hostname resolution for local network requests
  * Optimized local connection handling to improve request routing efficiency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->