### PR TITLE
[ONCALL-280] fix: requestly collections partially importing in local workspace

### DIFF
--- a/src/renderer/actions/local-sync/schemas.ts
+++ b/src/renderer/actions/local-sync/schemas.ts
@@ -53,10 +53,10 @@ export enum KeyValueDataType {
 }
 
 const KeyValuePair = Type.Object({
-  id: Type.Number(),
+  id: Type.Optional(Type.Number()),
   key: Type.String(),
   value: Type.String(),
-  isEnabled: Type.Boolean(),
+  isEnabled: Type.Optional(Type.Boolean()),
   type: Type.Optional(Type.String()),
   description: Type.Optional(Type.String()),
   dataType: Type.Optional(Type.Enum(KeyValueDataType)),


### PR DESCRIPTION
Root cause: When header, query params or path params existed without id or isEnabled, it was leading to request getting not imported.
```
[
                {
                    "key": "Accept",
                    "isEnabled": true,
                    "value": "application/json"
                }
            ],
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation requirements for HTTP headers and query parameters to support optional identifier and enabled status fields, allowing greater flexibility in request configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->