### PR TITLE
ENGG-5319 : Fix form-urlencoded body handling for GET requests

### DIFF
--- a/src/main/actions/makeApiClientRequest.js
+++ b/src/main/actions/makeApiClientRequest.js
@@ -23,10 +23,7 @@ const makeApiClientRequest = async ({ apiRequest }) => {
       headers[key] = value;
     });
 
-    if (
-      method !== "HEAD" &&
-      apiRequest.contentType === "application/x-www-form-urlencoded"
-    ) {
+    if (apiRequest.contentType === "application/x-www-form-urlencoded") {
       const formData = new FormData();
       body?.forEach(({ key, value }) => {
         formData.append(key, value);


### PR DESCRIPTION
  ## Summary
  - Removed GET from the form-urlencoded body processing exclusion list so that GET requests with `application/x-www-form-urlencoded` content type are properly encoded

  ## Context
  The web app now allows GET request bodies in desktop mode. All content types (JSON, raw, multipart) were already handled correctly for GET, but form-urlencoded was explicitly skipped — causing the raw key-value pair array to be sent
  instead of properly encoded `URLSearchParams`.

  ## Changes
  - **`makeApiClientRequest.js`**: Changed `!["GET", "HEAD"].includes(method)` to `method !== "HEAD"` in the form-urlencoded body processing condition

  ## Test plan
  - [ ] Send GET request with `application/x-www-form-urlencoded` body → server should receive properly encoded form data (e.g. `key1=value1&key2=value2`)
  - [ ] Send GET request with JSON body → should still work as before
  - [ ] Send GET request with raw body → should still work as before
  - [ ] Send POST/PUT/PATCH with form-urlencoded body → should still work as before
  - [ ] HEAD requests should still have no body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form-urlencoded request handling to apply consistently across all HTTP methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->