### PR TITLE
Added logic for keeping background process runing on closing of debug…

### DIFF
--- a/src/main/actions/cleanup.js
+++ b/src/main/actions/cleanup.js
@@ -19,7 +19,6 @@ export const getReadyToQuitApp = async  () => {
     cleanup();
   
     if (global.backgroundWindow) {
-      // Set flag to allow background window destruction
       global.allowBackgroundWindowDestruction = true;
 
       let timeoutHandle;
@@ -30,7 +29,6 @@ export const getReadyToQuitApp = async  () => {
           global.backgroundWindow &&
           !global.backgroundWindow.isDestroyed()
         ) {
-          // When app is actually quitting, use the original destroy
           if (global.backgroundWindow._originalDestroy) {
             global.backgroundWindow._originalDestroy();
           } else {
@@ -40,7 +38,6 @@ export const getReadyToQuitApp = async  () => {
         resolve();
       });
       
-      // Timeout fallback in case shutdown-success never comes
       timeoutHandle = setTimeout(() => {
         if (global.backgroundWindow && !global.backgroundWindow.isDestroyed()) {
           if (global.backgroundWindow._originalDestroy) {


### PR DESCRIPTION
In startBackgroundProcess.js, the background window is now shielded from accidental destruction the close event is intercepted to hide instead of close; destroy is overridden so it only destroys when a new quit flag (global.allowBackgroundWindowDestruction) is set; removeAllListeners is wrapped so the close handler can’t be removed; and a backgroundProcessStarted flag is recorded. Initial behavior: the window could be closed/destroyed normally, so accidental teardown was possible.
In cleanup.js, quitting now sets allowBackgroundWindowDestruction, waits for shutdown-success, restores the original destroy when quitting, and adds a 2s fallback timer to force-destroy if the shutdown signal never arrives. Initial behavior: it just listened for shutdown-success and immediately closed/destroyed the window without guarding against missed events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background window now hides instead of closing and reopens developer tools whenever it loads or is shown.
  * Tracks background process state to manage reopen and visibility behavior.

* **Bug Fixes**
  * More reliable shutdown with a 2s timed fallback to enforce cleanup on quit.
  * Prevents accidental background-window destruction except during intentional quit, reducing unexpected terminations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->