### PR TITLE
[DB-48] added persistence to secret values

### DIFF
--- a/src/lib/secretsManager/baseTypes.ts
+++ b/src/lib/secretsManager/baseTypes.ts
@@ -25,6 +25,7 @@ export interface ProviderConfig<T extends SecretProviderType, C> {
  * @template T - The provider type
  */
 export interface SecretReference<T extends SecretProviderType> {
+  id: string;
   type: T;
   alias: string;
 }

--- a/src/lib/secretsManager/encryptedStorage/AbstractSecretsManagerStorage.ts
+++ b/src/lib/secretsManager/encryptedStorage/AbstractSecretsManagerStorage.ts
@@ -1,17 +1,35 @@
-import { SecretProviderConfig } from "../types";
+import { SecretProviderConfig, SecretValue } from "../types";
 
-export type StorageChangeCallback = (
-  data: Record<string, SecretProviderConfig>
+export type ProviderStorageChangeCallback = (
+  providers: Record<string, SecretProviderConfig>
+) => void;
+export type SecretStorageChangeCallback = (
+  secrets: Record<string, SecretValue>
 ) => void;
 
 export abstract class AbstractSecretsManagerStorage {
-  abstract set(_key: string, _data: SecretProviderConfig): Promise<void>;
+  abstract setProviderConfig(
+    _providerId: string,
+    _data: SecretProviderConfig
+  ): Promise<void>;
+  abstract setSecretValue(_secretId: string, _data: SecretValue): Promise<void>;
+  abstract setSecretValues(
+    _entries: Record<string, SecretValue>
+  ): Promise<void>;
 
-  abstract get(_key: string): Promise<SecretProviderConfig | null>;
+  abstract getProviderConfig(
+    _providerId: string
+  ): Promise<SecretProviderConfig | null>;
+  abstract getSecretValue(_secretId: string): Promise<SecretValue | null>;
 
-  abstract getAll(): Promise<SecretProviderConfig[]>;
+  abstract getAllProviderConfigs(): Promise<SecretProviderConfig[]>;
+  abstract getAllSecretValues(): Promise<SecretValue[]>;
+  abstract deleteProviderConfig(_providerId: string): Promise<void>;
+  abstract deleteSecretValue(_secretId: string): Promise<void>;
+  abstract deleteSecretValues(_keys: string[]): Promise<void>;
 
-  abstract delete(_key: string): Promise<void>;
-
-  abstract onStorageChange(callback: StorageChangeCallback): () => void;
+  abstract onProvidersChange(
+    callback: ProviderStorageChangeCallback
+  ): () => void;
+  abstract onSecretsChange(callback: SecretStorageChangeCallback): () => void;
 }

--- a/src/lib/secretsManager/encryptedStorage/SecretsManagerEncryptedStorage.ts
+++ b/src/lib/secretsManager/encryptedStorage/SecretsManagerEncryptedStorage.ts
@@ -1,9 +1,10 @@
 import {
   AbstractSecretsManagerStorage,
-  StorageChangeCallback,
+  ProviderStorageChangeCallback,
+  SecretStorageChangeCallback,
 } from "./AbstractSecretsManagerStorage";
 import { EncryptedElectronStore } from "../../storage/EncryptedElectronStore";
-import { SecretProviderConfig } from "../types";
+import { SecretProviderConfig, SecretReference, SecretValue } from "../types";
 
 export class SecretsManagerEncryptedStorage extends AbstractSecretsManagerStorage {
   private encryptedStore: EncryptedElectronStore;
@@ -13,25 +14,82 @@ export class SecretsManagerEncryptedStorage extends AbstractSecretsManagerStorag
     this.encryptedStore = new EncryptedElectronStore(storeName);
   }
 
-  async set(key: string, data: SecretProviderConfig): Promise<void> {
-    return this.encryptedStore.set<SecretProviderConfig>(key, data);
+  async setProviderConfig(
+    providerId: string,
+    data: SecretProviderConfig
+  ): Promise<void> {
+    return this.encryptedStore.set<SecretProviderConfig>(
+      `providers.${providerId}`,
+      data
+    );
   }
 
-  async get(key: string): Promise<SecretProviderConfig | null> {
-    return this.encryptedStore.get<SecretProviderConfig>(key);
+  async setSecretValue(secretId: string, data: SecretValue): Promise<void> {
+    return this.encryptedStore.set<SecretValue>(`secrets.${secretId}`, data);
   }
 
-  async getAll(): Promise<SecretProviderConfig[]> {
-    const allData =
-      this.encryptedStore.getAll<Record<string, SecretProviderConfig>>();
-    return Object.values(allData);
+  async setSecretValues(entries: Record<string, SecretValue>): Promise<void> {
+    const current =
+      this.encryptedStore.get<Record<string, SecretValue>>("secrets") ?? {};
+    this.encryptedStore.set<Record<string, SecretValue>>("secrets", {
+      ...current,
+      ...entries,
+    });
   }
 
-  async delete(key: string): Promise<void> {
-    return this.encryptedStore.delete(key);
+  async getProviderConfig(
+    providerId: string
+  ): Promise<SecretProviderConfig | null> {
+    return this.encryptedStore.get<SecretProviderConfig>(
+      `providers.${providerId}`
+    );
   }
 
-  onStorageChange(callback: StorageChangeCallback): () => void {
-    return this.encryptedStore.onChange<SecretProviderConfig>(callback);
+  async getSecretValue(secretId: string): Promise<SecretValue | null> {
+    return this.encryptedStore.get<SecretValue>(`secrets.${secretId}`);
+  }
+
+  async getAllProviderConfigs(): Promise<SecretProviderConfig[]> {
+    const allProviders =
+      this.encryptedStore.get<Record<string, SecretProviderConfig>>(
+        `providers`
+      );
+    return Object.values(allProviders ?? {});
+  }
+
+  async getAllSecretValues(): Promise<SecretValue[]> {
+    const allSecrets =
+      this.encryptedStore.get<Record<string, SecretValue>>(`secrets`);
+    return Object.values(allSecrets ?? {});
+  }
+
+  async deleteProviderConfig(providerId: string): Promise<void> {
+    return this.encryptedStore.delete(`providers.${providerId}`);
+  }
+
+  async deleteSecretValue(secretId: string): Promise<void> {
+    return this.encryptedStore.delete(`secrets.${secretId}`);
+  }
+
+  async deleteSecretValues(keys: string[]): Promise<void> {
+    const current =
+      this.encryptedStore.get<Record<string, SecretValue>>("secrets") ?? {};
+    for (const key of keys) {
+      delete current[key];
+    }
+    this.encryptedStore.set<Record<string, SecretValue>>("secrets", current);
+  }
+
+  onProvidersChange(callback: ProviderStorageChangeCallback): () => void {
+    return this.encryptedStore.onKeyChange<
+      Record<string, SecretProviderConfig>
+    >("providers", callback);
+  }
+
+  onSecretsChange(callback: SecretStorageChangeCallback): () => void {
+    return this.encryptedStore.onKeyChange<Record<string, SecretValue>>(
+      "secrets",
+      callback
+    );
   }
 }

--- a/src/lib/secretsManager/encryptedStorage/SecretsManagerEncryptedStorage.ts
+++ b/src/lib/secretsManager/encryptedStorage/SecretsManagerEncryptedStorage.ts
@@ -9,9 +9,10 @@ import { SecretProviderConfig, SecretReference, SecretValue } from "../types";
 export class SecretsManagerEncryptedStorage extends AbstractSecretsManagerStorage {
   private encryptedStore: EncryptedElectronStore;
 
-  constructor(storeName: string) {
+  constructor(storeName: string, userId: string) {
     super();
     this.encryptedStore = new EncryptedElectronStore(storeName);
+    this.encryptedStore.set("userId", userId);
   }
 
   async setProviderConfig(

--- a/src/lib/secretsManager/errors.ts
+++ b/src/lib/secretsManager/errors.ts
@@ -1,4 +1,4 @@
-import { SecretReference } from "./types";
+import { SecretReference, SecretValue } from "./types";
 
 export enum SecretsErrorCode {
   SAFE_STORAGE_ENCRYPTION_NOT_AVAILABLE = "safe_storage_encryption_not_available",
@@ -37,6 +37,16 @@ export type SecretsSuccess<T> = T extends void
 export type SecretsResult<T> = SecretsSuccess<T> | SecretsManagerError;
 
 export type SecretsResultPromise<T> = Promise<SecretsResult<T>>;
+
+export interface SecretFetchError {
+  secretRefId: string;
+  message: string;
+}
+
+export interface FetchSecretsResultData {
+  secrets: SecretValue[];
+  errors: SecretFetchError[];
+}
 
 export function createSecretsError(
   code: SecretsErrorCode,

--- a/src/lib/secretsManager/errors.ts
+++ b/src/lib/secretsManager/errors.ts
@@ -2,6 +2,7 @@ import { SecretReference, SecretValue } from "./types";
 
 export enum SecretsErrorCode {
   SAFE_STORAGE_ENCRYPTION_NOT_AVAILABLE = "safe_storage_encryption_not_available",
+  INVALID_USER_ID = "invalid_user_id",
 
   PROVIDER_NOT_FOUND = "provider_not_found",
 

--- a/src/lib/secretsManager/index.ts
+++ b/src/lib/secretsManager/index.ts
@@ -59,6 +59,12 @@ export const initSecretsManager = async (
   userId: string
 ): SecretsResultPromise<void> => {
   try {
+    if(!userId){
+      return createSecretsError(
+        SecretsErrorCode.INVALID_USER_ID,
+        "Invalid user ID provided for SecretsManager initialization."
+      );
+    }
     const storeName = `sm-${userId}`;
     const secretsStorage = new SecretsManagerEncryptedStorage(
       storeName,

--- a/src/lib/secretsManager/index.ts
+++ b/src/lib/secretsManager/index.ts
@@ -1,4 +1,9 @@
 import { SecretsManagerEncryptedStorage } from "./encryptedStorage/SecretsManagerEncryptedStorage";
+import {
+  AbstractSecretsManagerStorage,
+  ProviderStorageChangeCallback,
+  SecretStorageChangeCallback,
+} from "./encryptedStorage/AbstractSecretsManagerStorage";
 import { FileBasedProviderRegistry } from "./providerRegistry/FileBasedProviderRegistry";
 import { ProviderChangeCallback } from "./providerRegistry/AbstractProviderRegistry";
 import { SecretsManager } from "./secretsManager";
@@ -15,6 +20,33 @@ import {
 } from "./errors";
 import { createProviderInstance } from "./providerService/providerFactory";
 
+export class NoopSecretsManagerStorage extends AbstractSecretsManagerStorage {
+  async setProviderConfig(): Promise<void> {}
+  async setSecretValue(): Promise<void> {}
+  async setSecretValues(): Promise<void> {}
+  async deleteSecretValues(): Promise<void> {}
+  async getProviderConfig(): Promise<null> {
+    return null;
+  }
+  async getSecretValue(): Promise<null> {
+    return null;
+  }
+  async getAllProviderConfigs(): Promise<[]> {
+    return [];
+  }
+  async getAllSecretValues(): Promise<[]> {
+    return [];
+  }
+  async deleteProviderConfig(): Promise<void> {}
+  async deleteSecretValue(): Promise<void> {}
+  onProvidersChange(_callback: ProviderStorageChangeCallback): () => void {
+    return () => {};
+  }
+  onSecretsChange(_callback: SecretStorageChangeCallback): () => void {
+    return () => {};
+  }
+}
+
 const getSecretsManager = (): SecretsManager => {
   if (!SecretsManager.isInitialized()) {
     return null as any;
@@ -22,13 +54,12 @@ const getSecretsManager = (): SecretsManager => {
   return SecretsManager.getInstance();
 };
 
-const PROVIDERS_DIRECTORY = "providers";
-
-export const initSecretsManager = async (): SecretsResultPromise<void> => {
+export const initSecretsManager = async (
+  userId: string
+): SecretsResultPromise<void> => {
   try {
-    const secretsStorage = new SecretsManagerEncryptedStorage(
-      PROVIDERS_DIRECTORY
-    );
+    const storeName = `sm-${userId}`;
+    const secretsStorage = new SecretsManagerEncryptedStorage(storeName);
     const registry = new FileBasedProviderRegistry(secretsStorage);
 
     await SecretsManager.initialize(registry);
@@ -112,11 +143,27 @@ export const listSecretProviders = async (): SecretsResultPromise<
   return getSecretsManager().listProviders();
 };
 
+export const removeSecretValue = async (
+  providerId: string,
+  ref: SecretReference
+): SecretsResultPromise<void> => {
+  return getSecretsManager().removeSecret(providerId, ref);
+};
+
+export const removeSecretValues = async (
+  secrets: Array<{ providerId: string; ref: SecretReference }>
+): SecretsResultPromise<void> => {
+  return getSecretsManager().removeSecrets(secrets);
+};
+
 export const testSecretProviderConnectionWithConfig = async (
   config: SecretProviderConfig
 ): SecretsResultPromise<boolean> => {
   try {
-    const provider = createProviderInstance(config);
+    const provider = createProviderInstance(
+      config,
+      new NoopSecretsManagerStorage()
+    );
     const isConnected = await provider.testConnection();
     return { type: "success", data: isConnected ?? false };
   } catch (error) {

--- a/src/lib/secretsManager/index.ts
+++ b/src/lib/secretsManager/index.ts
@@ -22,10 +22,10 @@ import {
 import { createProviderInstance } from "./providerService/providerFactory";
 
 export class NoopSecretsManagerStorage extends AbstractSecretsManagerStorage {
-  async setProviderConfig(): Promise<void> { }
-  async setSecretValue(): Promise<void> { }
-  async setSecretValues(): Promise<void> { }
-  async deleteSecretValues(): Promise<void> { }
+  async setProviderConfig(): Promise<void> {}
+  async setSecretValue(): Promise<void> {}
+  async setSecretValues(): Promise<void> {}
+  async deleteSecretValues(): Promise<void> {}
   async getProviderConfig(): Promise<null> {
     return null;
   }
@@ -38,13 +38,13 @@ export class NoopSecretsManagerStorage extends AbstractSecretsManagerStorage {
   async getAllSecretValues(): Promise<[]> {
     return [];
   }
-  async deleteProviderConfig(): Promise<void> { }
-  async deleteSecretValue(): Promise<void> { }
+  async deleteProviderConfig(): Promise<void> {}
+  async deleteSecretValue(): Promise<void> {}
   onProvidersChange(_callback: ProviderStorageChangeCallback): () => void {
-    return () => { };
+    return () => {};
   }
   onSecretsChange(_callback: SecretStorageChangeCallback): () => void {
-    return () => { };
+    return () => {};
   }
 }
 
@@ -60,7 +60,10 @@ export const initSecretsManager = async (
 ): SecretsResultPromise<void> => {
   try {
     const storeName = `sm-${userId}`;
-    const secretsStorage = new SecretsManagerEncryptedStorage(storeName);
+    const secretsStorage = new SecretsManagerEncryptedStorage(
+      storeName,
+      userId
+    );
     const registry = new FileBasedProviderRegistry(secretsStorage);
 
     SecretsManager.reset();
@@ -177,7 +180,6 @@ export const testSecretProviderConnectionWithConfig = async (
     );
   }
 };
-
 
 export const listSecrets = async (
   providerId: string

--- a/src/lib/secretsManager/index.ts
+++ b/src/lib/secretsManager/index.ts
@@ -63,6 +63,7 @@ export const initSecretsManager = async (
     const secretsStorage = new SecretsManagerEncryptedStorage(storeName);
     const registry = new FileBasedProviderRegistry(secretsStorage);
 
+    SecretsManager.reset();
     await SecretsManager.initialize(registry);
 
     return {

--- a/src/lib/secretsManager/index.ts
+++ b/src/lib/secretsManager/index.ts
@@ -17,6 +17,7 @@ import {
   createSecretsError,
   SecretsErrorCode,
   SecretsResultPromise,
+  FetchSecretsResultData,
 } from "./errors";
 import { createProviderInstance } from "./providerService/providerFactory";
 
@@ -134,7 +135,7 @@ export const getSecretValues = async (
 export const fetchAndSaveSecrets = async (
   providerId: string,
   secretRefs: SecretReference[]
-): SecretsResultPromise<(SecretValue | null)[]> => {
+): SecretsResultPromise<FetchSecretsResultData> => {
   return getSecretsManager().fetchAndSaveSecrets(providerId, secretRefs);
 };
 

--- a/src/lib/secretsManager/index.ts
+++ b/src/lib/secretsManager/index.ts
@@ -21,10 +21,10 @@ import {
 import { createProviderInstance } from "./providerService/providerFactory";
 
 export class NoopSecretsManagerStorage extends AbstractSecretsManagerStorage {
-  async setProviderConfig(): Promise<void> {}
-  async setSecretValue(): Promise<void> {}
-  async setSecretValues(): Promise<void> {}
-  async deleteSecretValues(): Promise<void> {}
+  async setProviderConfig(): Promise<void> { }
+  async setSecretValue(): Promise<void> { }
+  async setSecretValues(): Promise<void> { }
+  async deleteSecretValues(): Promise<void> { }
   async getProviderConfig(): Promise<null> {
     return null;
   }
@@ -37,13 +37,13 @@ export class NoopSecretsManagerStorage extends AbstractSecretsManagerStorage {
   async getAllSecretValues(): Promise<[]> {
     return [];
   }
-  async deleteProviderConfig(): Promise<void> {}
-  async deleteSecretValue(): Promise<void> {}
+  async deleteProviderConfig(): Promise<void> { }
+  async deleteSecretValue(): Promise<void> { }
   onProvidersChange(_callback: ProviderStorageChangeCallback): () => void {
-    return () => {};
+    return () => { };
   }
   onSecretsChange(_callback: SecretStorageChangeCallback): () => void {
-    return () => {};
+    return () => { };
   }
 }
 
@@ -131,10 +131,11 @@ export const getSecretValues = async (
   return getSecretsManager().getSecrets(secrets);
 };
 
-export const refreshSecrets = async (
-  providerId: string
+export const fetchAndSaveSecrets = async (
+  providerId: string,
+  secretRefs: SecretReference[]
 ): SecretsResultPromise<(SecretValue | null)[]> => {
-  return getSecretsManager().refreshSecrets(providerId);
+  return getSecretsManager().fetchAndSaveSecrets(providerId, secretRefs);
 };
 
 export const listSecretProviders = async (): SecretsResultPromise<
@@ -173,4 +174,11 @@ export const testSecretProviderConnectionWithConfig = async (
       { providerId: config.id, cause: error as Error }
     );
   }
+};
+
+
+export const listSecrets = async (
+  providerId: string
+): SecretsResultPromise<SecretValue[]> => {
+  return getSecretsManager().listSecrets(providerId);
 };

--- a/src/lib/secretsManager/providerRegistry/FileBasedProviderRegistry.ts
+++ b/src/lib/secretsManager/providerRegistry/FileBasedProviderRegistry.ts
@@ -17,27 +17,26 @@ export class FileBasedProviderRegistry extends AbstractProviderRegistry {
   private async initProvidersFromStorage(): Promise<void> {
     const configs = await this.getAllProviderConfigs();
     configs.forEach((config) => {
-      this.providers.set(config.id, createProviderInstance(config)); // TODO: check if this needs error handling
+      this.providers.set(config.id, createProviderInstance(config, this.store));
     });
   }
 
   async getAllProviderConfigs(): Promise<SecretProviderConfig[]> {
-    const allConfigs = this.store.getAll();
-    return allConfigs;
+    return this.store.getAllProviderConfigs();
   }
 
   async getProviderConfig(id: string): Promise<SecretProviderConfig | null> {
-    return this.store.get(id);
+    return this.store.getProviderConfig(id);
   }
 
   async setProviderConfig(config: SecretProviderConfig): Promise<void> {
-    const provider = createProviderInstance(config);
-    await this.store.set(config.id, config);
+    const provider = createProviderInstance(config, this.store);
+    await this.store.setProviderConfig(config.id, config);
     this.providers.set(config.id, provider);
   }
 
   async deleteProviderConfig(id: string): Promise<void> {
-    await this.store.delete(id);
+    await this.store.deleteProviderConfig(id);
     this.providers.delete(id);
   }
 
@@ -56,9 +55,9 @@ export class FileBasedProviderRegistry extends AbstractProviderRegistry {
   }
 
   private setupStorageListener(): void {
-    this.store.onStorageChange((data) => {
-      this.syncProvidersFromStorageData(data);
-      this.notifyChangeCallbacks(data);
+    this.store.onProvidersChange((providers) => {
+      this.syncProvidersFromStorageData(providers);
+      this.notifyChangeCallbacks(providers);
     });
   }
 
@@ -76,8 +75,7 @@ export class FileBasedProviderRegistry extends AbstractProviderRegistry {
     }
 
     for (const [id, config] of Object.entries(data)) {
-      // recreate provider instance
-      this.providers.set(id, createProviderInstance(config));
+      this.providers.set(id, createProviderInstance(config, this.store));
     }
   }
 

--- a/src/lib/secretsManager/providerService/AbstractSecretProvider.ts
+++ b/src/lib/secretsManager/providerService/AbstractSecretProvider.ts
@@ -2,7 +2,6 @@ import { SecretProviderType } from "../baseTypes";
 import {
   CredentialsForProvider,
   ReferenceForProvider,
-  SecretValue,
   ValueForProvider,
 } from "../types";
 import { AbstractSecretsManagerStorage } from "../encryptedStorage/AbstractSecretsManagerStorage";

--- a/src/lib/secretsManager/providerService/AbstractSecretProvider.ts
+++ b/src/lib/secretsManager/providerService/AbstractSecretProvider.ts
@@ -7,6 +7,11 @@ import {
 } from "../types";
 import { AbstractSecretsManagerStorage } from "../encryptedStorage/AbstractSecretsManagerStorage";
 
+export interface GetSecretValuesResult<T extends SecretProviderType> {
+  results: (ValueForProvider<T> | null)[];
+  errors: Array<{ ref: ReferenceForProvider<T>; message: string }>;
+}
+
 /**
  * Generic abstract base class for secret providers.
  *
@@ -39,7 +44,7 @@ export abstract class AbstractSecretProvider<T extends SecretProviderType> {
 
   abstract getSecretValues(
     _refs: ReferenceForProvider<T>[]
-  ): Promise<(ValueForProvider<T> | null)[]>;
+  ): Promise<GetSecretValuesResult<T>>;
 
   abstract setSecret(_value: ValueForProvider<T>): Promise<void>;
 

--- a/src/lib/secretsManager/providerService/AbstractSecretProvider.ts
+++ b/src/lib/secretsManager/providerService/AbstractSecretProvider.ts
@@ -33,11 +33,11 @@ export abstract class AbstractSecretProvider<T extends SecretProviderType> {
 
   abstract testConnection(): Promise<boolean>;
 
-  abstract getSecret(
+  abstract getSecretValue(
     _ref: ReferenceForProvider<T>
   ): Promise<ValueForProvider<T> | null>;
 
-  abstract getSecrets(
+  abstract getSecretValues(
     _refs: ReferenceForProvider<T>[]
   ): Promise<(ValueForProvider<T> | null)[]>;
 
@@ -53,7 +53,7 @@ export abstract class AbstractSecretProvider<T extends SecretProviderType> {
 
   abstract removeSecrets(_refs: ReferenceForProvider<T>[]): Promise<void>;
 
-  abstract refreshSecrets(): Promise<(ValueForProvider<T> | null)[]>;
+  abstract listAllSecrets(): Promise<(ValueForProvider<T>)[]>;
 
   static validateConfig(config: any): boolean {
     // Base implementation rejects all configs as a fail-safe.
@@ -63,34 +63,5 @@ export abstract class AbstractSecretProvider<T extends SecretProviderType> {
     }
 
     return false;
-  }
-
-  protected async getPersistedSecret(
-    key: string
-  ): Promise<ValueForProvider<T> | null> {
-    return this.store.getSecretValue(
-      key
-    ) as Promise<ValueForProvider<T> | null>;
-  }
-
-  protected async persistSecret(
-    key: string,
-    value: ValueForProvider<T>
-  ): Promise<void> {
-    return this.store.setSecretValue(key, value);
-  }
-
-  protected async persistSecrets(
-    entries: Record<string, ValueForProvider<T>>
-  ): Promise<void> {
-    return this.store.setSecretValues(entries as Record<string, SecretValue>);
-  }
-
-  protected async deletePersistedSecret(key: string): Promise<void> {
-    return this.store.deleteSecretValue(key);
-  }
-
-  protected async deletePersistedSecrets(keys: string[]): Promise<void> {
-    return this.store.deleteSecretValues(keys);
   }
 }

--- a/src/lib/secretsManager/providerService/AbstractSecretProvider.ts
+++ b/src/lib/secretsManager/providerService/AbstractSecretProvider.ts
@@ -2,11 +2,10 @@ import { SecretProviderType } from "../baseTypes";
 import {
   CredentialsForProvider,
   ReferenceForProvider,
+  SecretValue,
   ValueForProvider,
 } from "../types";
-
-const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-const DEFAULT_MAX_CACHE_SIZE = 100;
+import { AbstractSecretsManagerStorage } from "../encryptedStorage/AbstractSecretsManagerStorage";
 
 /**
  * Generic abstract base class for secret providers.
@@ -14,11 +13,7 @@ const DEFAULT_MAX_CACHE_SIZE = 100;
  * @template T - The provider type
  */
 export abstract class AbstractSecretProvider<T extends SecretProviderType> {
-  protected cache: Map<string, ValueForProvider<T>> = new Map();
-
-  protected cacheTtlMs: number = DEFAULT_CACHE_TTL_MS;
-
-  protected maxCacheSize: number = DEFAULT_MAX_CACHE_SIZE;
+  protected store: AbstractSecretsManagerStorage;
 
   abstract readonly type: T;
 
@@ -26,7 +21,15 @@ export abstract class AbstractSecretProvider<T extends SecretProviderType> {
 
   protected abstract config: CredentialsForProvider<T>;
 
-  protected abstract getCacheKey(_ref: ReferenceForProvider<T>): string;
+  /**
+   * Returns the key used to persist/retrieve this secret in the store.
+   * Must be unique across all secrets for this provider.
+   */
+  protected abstract getStorageKey(_ref: ReferenceForProvider<T>): string;
+
+  constructor(store: AbstractSecretsManagerStorage) {
+    this.store = store;
+  }
 
   abstract testConnection(): Promise<boolean>;
 
@@ -38,15 +41,11 @@ export abstract class AbstractSecretProvider<T extends SecretProviderType> {
     _refs: ReferenceForProvider<T>[]
   ): Promise<(ValueForProvider<T> | null)[]>;
 
-  abstract setSecret(
-    _ref: ReferenceForProvider<T>,
-    _value: string | Record<string, any>
-  ): Promise<void>;
+  abstract setSecret(_value: ValueForProvider<T>): Promise<void>;
 
   abstract setSecrets(
     _entries: Array<{
-      ref: ReferenceForProvider<T>;
-      value: string | Record<string, any>;
+      value: ValueForProvider<T>;
     }>
   ): Promise<void>;
 
@@ -66,46 +65,32 @@ export abstract class AbstractSecretProvider<T extends SecretProviderType> {
     return false;
   }
 
-  protected invalidateCache(): void {
-    this.cache.clear();
+  protected async getPersistedSecret(
+    key: string
+  ): Promise<ValueForProvider<T> | null> {
+    return this.store.getSecretValue(
+      key
+    ) as Promise<ValueForProvider<T> | null>;
   }
 
-  protected getCachedSecret(key: string): ValueForProvider<T> | null {
-    const cached = this.cache.get(key);
-    if (cached && cached.fetchedAt + this.cacheTtlMs > Date.now()) {
-      return cached;
-    }
-    return null;
+  protected async persistSecret(
+    key: string,
+    value: ValueForProvider<T>
+  ): Promise<void> {
+    return this.store.setSecretValue(key, value);
   }
 
-  protected setCacheEntry(key: string, value: ValueForProvider<T>): void {
-    if (this.maxCacheSize <= 0) {
-      return;
-    }
-
-    this.evictExpiredEntries();
-
-    while (this.cache.size >= this.maxCacheSize) {
-      const oldestKey = this.cache.keys().next().value;
-      if (!oldestKey) {
-        break;
-      }
-      this.cache.delete(oldestKey);
-    }
-
-    this.cache.set(key, value);
+  protected async persistSecrets(
+    entries: Record<string, ValueForProvider<T>>
+  ): Promise<void> {
+    return this.store.setSecretValues(entries as Record<string, SecretValue>);
   }
 
-  protected evictExpiredEntries(): void {
-    const now = Date.now();
-    const keysToDelete: string[] = [];
+  protected async deletePersistedSecret(key: string): Promise<void> {
+    return this.store.deleteSecretValue(key);
+  }
 
-    this.cache.forEach((value, key) => {
-      if (value.fetchedAt + this.cacheTtlMs <= now) {
-        keysToDelete.push(key);
-      }
-    });
-
-    keysToDelete.forEach((key) => this.cache.delete(key));
+  protected async deletePersistedSecrets(keys: string[]): Promise<void> {
+    return this.store.deleteSecretValues(keys);
   }
 }

--- a/src/lib/secretsManager/providerService/awsSecretManagerProvider.ts
+++ b/src/lib/secretsManager/providerService/awsSecretManagerProvider.ts
@@ -118,15 +118,29 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
 
   async getSecretValues(
     refs: AwsSecretReference[]
-  ): Promise<(AwsSecretValue | null)[]> {
+  ): Promise<{ results: (AwsSecretValue | null)[]; errors: Array<{ ref: AwsSecretReference; message: string }> }> {
     if (!this.client) {
       throw new Error("AWS Secrets Manager client is not initialized.");
     }
 
-    // Not using BatchGetSecretValueCommand as it would require additional permissions
-    // TODO@nafees: check for null values and verify if error thrown - handle partial failures appropriately
-    const secretValues = await Promise.all(refs.map((ref) => this.getSecretValue(ref)));
-    return secretValues;
+    const settled = await Promise.allSettled(refs.map((ref) => this.getSecretValue(ref)));
+    const results: (AwsSecretValue | null)[] = [];
+    const errors: Array<{ ref: AwsSecretReference; message: string }> = [];
+
+    for (let i = 0; i < settled.length; i++) {
+      const r = settled[i];
+      if (r.status === "fulfilled") {
+        results.push(r.value);
+      } else {
+        results.push(null);
+        errors.push({
+          ref: refs[i],
+          message: r.reason instanceof Error ? r.reason.message : String(r.reason),
+        });
+      }
+    }
+
+    return { results, errors };
   }
 
   // upserts a secret in the store

--- a/src/lib/secretsManager/providerService/awsSecretManagerProvider.ts
+++ b/src/lib/secretsManager/providerService/awsSecretManagerProvider.ts
@@ -1,5 +1,10 @@
-import { SecretProviderType, ProviderConfig, SecretReference } from "../baseTypes";
+import {
+  SecretProviderType,
+  ProviderConfig,
+  SecretReference,
+} from "../baseTypes";
 import { AbstractSecretProvider } from "./AbstractSecretProvider";
+import { AbstractSecretsManagerStorage } from "../encryptedStorage/AbstractSecretsManagerStorage";
 import {
   GetSecretValueCommand,
   GetSecretValueCommandOutput,
@@ -19,7 +24,8 @@ export type AWSSecretProviderConfig = ProviderConfig<
   AWSSecretsManagerCredentials
 >;
 
-export interface AwsSecretReference extends SecretReference<SecretProviderType.AWS_SECRETS_MANAGER> {
+export interface AwsSecretReference
+  extends SecretReference<SecretProviderType.AWS_SECRETS_MANAGER> {
   identifier: string;
   version?: string;
 }
@@ -44,8 +50,11 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
 
   private client: SecretsManagerClient;
 
-  constructor(providerConfig: AWSSecretProviderConfig) {
-    super();
+  constructor(
+    providerConfig: AWSSecretProviderConfig,
+    store: AbstractSecretsManagerStorage
+  ) {
+    super(store);
     this.id = providerConfig.id;
     this.config = providerConfig.credentials;
     this.client = new SecretsManagerClient({
@@ -58,8 +67,10 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
     });
   }
 
-  protected getCacheKey(ref: AwsSecretReference): string {
-    return `name:${ref.identifier};version:${ref.version ?? "latest"}`;
+  protected getStorageKey(ref: AwsSecretReference): string {
+    return `${this.id}:name:${ref.identifier};version:${
+      ref.version ?? "latest"
+    }`;
   }
 
   async testConnection(): Promise<boolean> {
@@ -67,10 +78,8 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
       return false;
     }
 
-
     const listSecretsCommand = new ListSecretsCommand({ MaxResults: 1 });
     const res = await this.client.send(listSecretsCommand);
-    console.log("!!!debug", "aws result", res);
 
     if (res.$metadata.httpStatusCode !== 200) {
       return false;
@@ -84,14 +93,11 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
       throw new Error("AWS Secrets Manager client is not initialized.");
     }
 
-    const cacheKey = this.getCacheKey(ref);
-    const cachedSecret = this.getCachedSecret(
-      cacheKey
-    ) as AwsSecretValue | null;
+    const storageKey = this.getStorageKey(ref);
+    const persisted = await this.getPersistedSecret(storageKey);
 
-    if (cachedSecret) {
-      console.log("!!!debug", "returning from cache", cachedSecret);
-      return cachedSecret;
+    if (persisted) {
+      return persisted as AwsSecretValue;
     }
 
     const getSecretCommand = new GetSecretValueCommand({
@@ -116,7 +122,7 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
       versionId: secretResponse.VersionId,
     };
 
-    this.setCacheEntry(cacheKey, awsSecret);
+    await this.persistSecret(storageKey, awsSecret);
 
     return awsSecret;
   }
@@ -132,30 +138,39 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
     return Promise.all(refs.map((ref) => this.getSecret(ref)));
   }
 
-  async setSecret(): Promise<void> {
-    throw new Error("Method not implemented.");
+  async setSecret(value: AwsSecretValue): Promise<void> {
+    await this.persistSecret(this.getStorageKey(value.secretReference), value);
   }
 
-  async setSecrets(): Promise<void> {
-    throw new Error("Method not implemented.");
+  async setSecrets(entries: Array<{ value: AwsSecretValue }>): Promise<void> {
+    const toSet: Record<string, AwsSecretValue> = {};
+    for (const entry of entries) {
+      toSet[this.getStorageKey(entry.value.secretReference)] = entry.value;
+    }
+    await this.persistSecrets(toSet);
   }
 
-  async removeSecret(): Promise<void> {
-    throw new Error("Method not implemented.");
+  async removeSecret(ref: AwsSecretReference): Promise<void> {
+    await this.deletePersistedSecret(this.getStorageKey(ref));
   }
 
-  async removeSecrets(): Promise<void> {
-    throw new Error("Method not implemented.");
+  async removeSecrets(refs: AwsSecretReference[]): Promise<void> {
+    await this.deletePersistedSecrets(
+      refs.map((ref) => this.getStorageKey(ref))
+    );
   }
 
   async refreshSecrets(): Promise<(AwsSecretValue | null)[]> {
-    const allSecretRefs = Array.from(this.cache.values()).map(
-      (secret) => secret.secretReference
+    const allSecrets = await this.store.getAllSecretValues();
+    const providerSecrets = allSecrets.filter(
+      (s) => s.providerId === this.id
+    ) as AwsSecretValue[];
+
+    await this.deletePersistedSecrets(
+      providerSecrets.map((s) => this.getStorageKey(s.secretReference))
     );
 
-    this.invalidateCache();
-
-    return this.getSecrets(allSecretRefs);
+    return this.getSecrets(providerSecrets.map((s) => s.secretReference));
   }
 
   static validateConfig(config: AWSSecretsManagerCredentials): boolean {

--- a/src/lib/secretsManager/providerService/awsSecretManagerProvider.ts
+++ b/src/lib/secretsManager/providerService/awsSecretManagerProvider.ts
@@ -86,7 +86,9 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
     return true;
   }
 
-  async getSecretValue(ref: AwsSecretReference): Promise<AwsSecretValue | null> {
+  async getSecretValue(
+    ref: AwsSecretReference
+  ): Promise<AwsSecretValue | null> {
     if (!this.client) {
       throw new Error("AWS Secrets Manager client is not initialized.");
     }
@@ -116,14 +118,17 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
     return awsSecret;
   }
 
-  async getSecretValues(
-    refs: AwsSecretReference[]
-  ): Promise<{ results: (AwsSecretValue | null)[]; errors: Array<{ ref: AwsSecretReference; message: string }> }> {
+  async getSecretValues(refs: AwsSecretReference[]): Promise<{
+    results: (AwsSecretValue | null)[];
+    errors: Array<{ ref: AwsSecretReference; message: string }>;
+  }> {
     if (!this.client) {
       throw new Error("AWS Secrets Manager client is not initialized.");
     }
 
-    const settled = await Promise.allSettled(refs.map((ref) => this.getSecretValue(ref)));
+    const settled = await Promise.allSettled(
+      refs.map((ref) => this.getSecretValue(ref))
+    );
     const results: (AwsSecretValue | null)[] = [];
     const errors: Array<{ ref: AwsSecretReference; message: string }> = [];
 
@@ -135,7 +140,8 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
         results.push(null);
         errors.push({
           ref: refs[i],
-          message: r.reason instanceof Error ? r.reason.message : String(r.reason),
+          message:
+            r.reason instanceof Error ? r.reason.message : String(r.reason),
         });
       }
     }
@@ -145,22 +151,28 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
 
   // upserts a secret in the store
   async setSecret(value: AwsSecretValue): Promise<void> {
-    await this.store.setSecretValue(this.getStorageKey(value.secretReference), value);
+    await this.store.setSecretValue(
+      this.getStorageKey(value.secretReference),
+      value
+    );
   }
 
   // removes and sets all the secrets for the provider
   async setSecrets(entries: Array<{ value: AwsSecretValue }>): Promise<void> {
-    const allSecrets = await this.listAllSecrets();
-
-    const toRemove = allSecrets.map((s) => this.getStorageKey(s.secretReference));
-
-    await this.store.deleteSecretValues(toRemove);
-
     const toSet: Record<string, AwsSecretValue> = {};
     for (const entry of entries) {
       toSet[this.getStorageKey(entry.value.secretReference)] = entry.value;
     }
+
+    const allSecrets = await this.listAllSecrets();
+    const newKeys = new Set(Object.keys(toSet));
+
+    const toRemove = allSecrets
+      .map((s) => this.getStorageKey(s.secretReference))
+      .filter((key) => !newKeys.has(key));
+
     await this.store.setSecretValues(toSet);
+    await this.store.deleteSecretValues(toRemove);
   }
 
   async removeSecret(ref: AwsSecretReference): Promise<void> {
@@ -173,7 +185,7 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
     );
   }
 
-  async listAllSecrets(): Promise<(AwsSecretValue)[]> {
+  async listAllSecrets(): Promise<AwsSecretValue[]> {
     const allSecrets = await this.store.getAllSecretValues();
     const providerSecrets = allSecrets.filter(
       (s) => s.providerId === this.id

--- a/src/lib/secretsManager/providerService/awsSecretManagerProvider.ts
+++ b/src/lib/secretsManager/providerService/awsSecretManagerProvider.ts
@@ -68,9 +68,7 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
   }
 
   protected getStorageKey(ref: AwsSecretReference): string {
-    return `${this.id}:name:${ref.identifier};version:${
-      ref.version ?? "latest"
-    }`;
+    return `${this.id}:${ref.id}`;
   }
 
   async testConnection(): Promise<boolean> {
@@ -88,16 +86,9 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
     return true;
   }
 
-  async getSecret(ref: AwsSecretReference): Promise<AwsSecretValue | null> {
+  async getSecretValue(ref: AwsSecretReference): Promise<AwsSecretValue | null> {
     if (!this.client) {
       throw new Error("AWS Secrets Manager client is not initialized.");
-    }
-
-    const storageKey = this.getStorageKey(ref);
-    const persisted = await this.getPersistedSecret(storageKey);
-
-    if (persisted) {
-      return persisted as AwsSecretValue;
     }
 
     const getSecretCommand = new GetSecretValueCommand({
@@ -122,12 +113,10 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
       versionId: secretResponse.VersionId,
     };
 
-    await this.persistSecret(storageKey, awsSecret);
-
     return awsSecret;
   }
 
-  async getSecrets(
+  async getSecretValues(
     refs: AwsSecretReference[]
   ): Promise<(AwsSecretValue | null)[]> {
     if (!this.client) {
@@ -135,42 +124,48 @@ export class AWSSecretsManagerProvider extends AbstractSecretProvider<SecretProv
     }
 
     // Not using BatchGetSecretValueCommand as it would require additional permissions
-    return Promise.all(refs.map((ref) => this.getSecret(ref)));
+    // TODO@nafees: check for null values and verify if error thrown - handle partial failures appropriately
+    const secretValues = await Promise.all(refs.map((ref) => this.getSecretValue(ref)));
+    return secretValues;
   }
 
+  // upserts a secret in the store
   async setSecret(value: AwsSecretValue): Promise<void> {
-    await this.persistSecret(this.getStorageKey(value.secretReference), value);
+    await this.store.setSecretValue(this.getStorageKey(value.secretReference), value);
   }
 
+  // removes and sets all the secrets for the provider
   async setSecrets(entries: Array<{ value: AwsSecretValue }>): Promise<void> {
+    const allSecrets = await this.listAllSecrets();
+
+    const toRemove = allSecrets.map((s) => this.getStorageKey(s.secretReference));
+
+    await this.store.deleteSecretValues(toRemove);
+
     const toSet: Record<string, AwsSecretValue> = {};
     for (const entry of entries) {
       toSet[this.getStorageKey(entry.value.secretReference)] = entry.value;
     }
-    await this.persistSecrets(toSet);
+    await this.store.setSecretValues(toSet);
   }
 
   async removeSecret(ref: AwsSecretReference): Promise<void> {
-    await this.deletePersistedSecret(this.getStorageKey(ref));
+    await this.store.deleteSecretValue(this.getStorageKey(ref));
   }
 
   async removeSecrets(refs: AwsSecretReference[]): Promise<void> {
-    await this.deletePersistedSecrets(
+    await this.store.deleteSecretValues(
       refs.map((ref) => this.getStorageKey(ref))
     );
   }
 
-  async refreshSecrets(): Promise<(AwsSecretValue | null)[]> {
+  async listAllSecrets(): Promise<(AwsSecretValue)[]> {
     const allSecrets = await this.store.getAllSecretValues();
     const providerSecrets = allSecrets.filter(
       (s) => s.providerId === this.id
     ) as AwsSecretValue[];
 
-    await this.deletePersistedSecrets(
-      providerSecrets.map((s) => this.getStorageKey(s.secretReference))
-    );
-
-    return this.getSecrets(providerSecrets.map((s) => s.secretReference));
+    return providerSecrets;
   }
 
   static validateConfig(config: AWSSecretsManagerCredentials): boolean {

--- a/src/lib/secretsManager/providerService/hashicorpVaultProvider.ts
+++ b/src/lib/secretsManager/providerService/hashicorpVaultProvider.ts
@@ -1,3 +1,4 @@
+import { NoopSecretsManagerStorage } from "..";
 import { SecretProviderType, ProviderConfig, SecretReference } from "../baseTypes";
 import { AbstractSecretProvider } from "./AbstractSecretProvider";
 
@@ -41,13 +42,14 @@ export class HashicorpVaultProvider extends AbstractSecretProvider<SecretProvide
   protected config: HashicorpVaultCredentials;
 
   constructor(providerConfig: HashicorpVaultProviderConfig) {
-    super();
+    super(new NoopSecretsManagerStorage());
     this.id = providerConfig.id;
     this.config = providerConfig.credentials;
   }
 
-  protected getCacheKey(ref: VaultSecretReference): string {
-    return `name:${ref.identifier};version:${ref.version ?? "latest"}`;
+  protected getStorageKey(ref: VaultSecretReference): string {
+    // NO-OP
+    return ref.identifier;
   }
 
   async testConnection(): Promise<boolean> {
@@ -63,14 +65,13 @@ export class HashicorpVaultProvider extends AbstractSecretProvider<SecretProvide
   }
 
   async setSecret(
-    _ref: VaultSecretReference,
-    _value: string | Record<string, any>
+    _value: VaultSecretValue
   ): Promise<void> {
     throw new Error("Method not implemented.");
   }
 
   async setSecrets(
-    _entries: Array<{ ref: VaultSecretReference; value: string | Record<string, any> }>
+    _entries: Array<{ value: string | Record<string, any> }>
   ): Promise<void> {
     throw new Error("Method not implemented.");
   }

--- a/src/lib/secretsManager/providerService/hashicorpVaultProvider.ts
+++ b/src/lib/secretsManager/providerService/hashicorpVaultProvider.ts
@@ -48,19 +48,18 @@ export class HashicorpVaultProvider extends AbstractSecretProvider<SecretProvide
   }
 
   protected getStorageKey(ref: VaultSecretReference): string {
-    // NO-OP
-    return ref.identifier;
+    return `${this.id}:${ref.id}`;
   }
 
   async testConnection(): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
 
-  async getSecret(_ref: VaultSecretReference): Promise<VaultSecretValue | null> {
+  async getSecretValue(_ref: VaultSecretReference): Promise<VaultSecretValue | null> {
     throw new Error("Method not implemented.");
   }
 
-  async getSecrets(_refs: VaultSecretReference[]): Promise<(VaultSecretValue | null)[]> {
+  async getSecretValues(_refs: VaultSecretReference[]): Promise<(VaultSecretValue | null)[]> {
     throw new Error("Method not implemented.");
   }
 
@@ -84,7 +83,7 @@ export class HashicorpVaultProvider extends AbstractSecretProvider<SecretProvide
     throw new Error("Method not implemented.");
   }
 
-  async refreshSecrets(): Promise<(VaultSecretValue | null)[]> {
+  async listAllSecrets(): Promise<(VaultSecretValue)[]> {
     throw new Error("Method not implemented.");
   }
 

--- a/src/lib/secretsManager/providerService/hashicorpVaultProvider.ts
+++ b/src/lib/secretsManager/providerService/hashicorpVaultProvider.ts
@@ -59,7 +59,7 @@ export class HashicorpVaultProvider extends AbstractSecretProvider<SecretProvide
     throw new Error("Method not implemented.");
   }
 
-  async getSecretValues(_refs: VaultSecretReference[]): Promise<(VaultSecretValue | null)[]> {
+  async getSecretValues(_refs: VaultSecretReference[]): Promise<{ results: (VaultSecretValue | null)[]; errors: Array<{ ref: VaultSecretReference; message: string }> }> {
     throw new Error("Method not implemented.");
   }
 

--- a/src/lib/secretsManager/providerService/providerFactory.ts
+++ b/src/lib/secretsManager/providerService/providerFactory.ts
@@ -1,14 +1,15 @@
 import { SecretProviderConfig, SecretProviderType } from "../types";
+import { AbstractSecretsManagerStorage } from "../encryptedStorage/AbstractSecretsManagerStorage";
 import { AWSSecretsManagerProvider } from "./awsSecretManagerProvider";
 import { AbstractSecretProvider } from "./AbstractSecretProvider";
 
 export function createProviderInstance(
-  config: SecretProviderConfig
+  config: SecretProviderConfig,
+  store: AbstractSecretsManagerStorage
 ): AbstractSecretProvider<SecretProviderType> {
   switch (config.type) {
     case SecretProviderType.AWS_SECRETS_MANAGER: {
-      // TypeScript knows config is AWSSecretProviderConfig here
-      return new AWSSecretsManagerProvider(config);
+      return new AWSSecretsManagerProvider(config, store);
     }
 
     default: {

--- a/src/lib/secretsManager/secretsManager.ts
+++ b/src/lib/secretsManager/secretsManager.ts
@@ -1,4 +1,9 @@
-import { SecretProviderConfig, SecretProviderMetadata, SecretReference, SecretValue } from "./types";
+import {
+  SecretProviderConfig,
+  SecretProviderMetadata,
+  SecretReference,
+  SecretValue,
+} from "./types";
 import {
   AbstractProviderRegistry,
   ProviderChangeCallback,
@@ -214,6 +219,69 @@ export class SecretsManager {
     return { type: "success", data: results };
   }
 
+  async removeSecret(
+    providerId: string,
+    ref: SecretReference
+  ): SecretsResultPromise<void> {
+    try {
+      const provider = this.registry.getProvider(providerId);
+      if (!provider) {
+        return createSecretsError(
+          SecretsErrorCode.PROVIDER_NOT_FOUND,
+          `Provider with id ${providerId} not found`,
+          { providerId }
+        );
+      }
+      await provider.removeSecret(ref);
+      return { type: "success" };
+    } catch (error) {
+      return createSecretsError(
+        SecretsErrorCode.STORAGE_WRITE_FAILED,
+        error instanceof Error
+          ? error.message
+          : `Failed to remove secret from provider ${providerId}`,
+        { providerId, secretRef: ref, cause: error as Error }
+      );
+    }
+  }
+
+  async removeSecrets(
+    secrets: Array<{ providerId: string; ref: SecretReference }>
+  ): SecretsResultPromise<void> {
+    const providerMap: Map<string, SecretReference[]> = new Map();
+
+    for (const s of secrets) {
+      if (!providerMap.has(s.providerId)) {
+        providerMap.set(s.providerId, []);
+      }
+      providerMap.get(s.providerId)?.push(s.ref);
+    }
+
+    for (const [providerId, refs] of providerMap.entries()) {
+      try {
+        const provider = this.registry.getProvider(providerId);
+        if (!provider) {
+          return createSecretsError(
+            SecretsErrorCode.PROVIDER_NOT_FOUND,
+            `Provider with id ${providerId} not found`,
+            { providerId }
+          );
+        }
+        await provider.removeSecrets(refs);
+      } catch (error) {
+        return createSecretsError(
+          SecretsErrorCode.STORAGE_WRITE_FAILED,
+          error instanceof Error
+            ? error.message
+            : `Failed to remove secrets from provider ${providerId}`,
+          { providerId, cause: error as Error }
+        );
+      }
+    }
+
+    return { type: "success" };
+  }
+
   async refreshSecrets(
     providerId: string
   ): SecretsResultPromise<(SecretValue | null)[]> {
@@ -242,13 +310,12 @@ export class SecretsManager {
     }
   }
 
-  async listProviders(): SecretsResultPromise<
-    SecretProviderMetadata[]
-  > {
+  async listProviders(): SecretsResultPromise<SecretProviderMetadata[]> {
     try {
       const configs = await this.registry.getAllProviderConfigs();
-      const configMetadata: SecretProviderMetadata[] =
-        configs.map(({ credentials: _, ...rest }) => rest);
+      const configMetadata: SecretProviderMetadata[] = configs.map(
+        ({ credentials: _, ...rest }) => rest
+      );
       return { type: "success", data: configMetadata };
     } catch (error) {
       return createSecretsError(

--- a/src/lib/secretsManager/secretsManager.ts
+++ b/src/lib/secretsManager/secretsManager.ts
@@ -2,6 +2,7 @@ import {
   AwsSecretValue,
   SecretProviderConfig,
   SecretProviderMetadata,
+  SecretProviderType,
   SecretReference,
   SecretValue,
 } from "./types";
@@ -13,6 +14,8 @@ import {
   SecretsResultPromise,
   createSecretsError,
   SecretsErrorCode,
+  SecretFetchError,
+  FetchSecretsResultData,
 } from "./errors";
 
 export class SecretsManager {
@@ -202,7 +205,7 @@ export class SecretsManager {
           );
         }
 
-        const secretValues = await provider.getSecretValues(refs);
+        const { results: secretValues } = await provider.getSecretValues(refs);
         results.push(
           ...secretValues.filter((sv): sv is SecretValue => sv !== null)
         );
@@ -286,7 +289,7 @@ export class SecretsManager {
   async fetchAndSaveSecrets(
     providerId: string,
     secretRefs: SecretReference[]
-  ): SecretsResultPromise<(SecretValue | null)[]> {
+  ): SecretsResultPromise<FetchSecretsResultData> {
     try {
       const provider = this.registry.getProvider(providerId);
 
@@ -298,13 +301,28 @@ export class SecretsManager {
         );
       }
 
-      const secrets = await provider.getSecretValues(secretRefs)
+      const { results, errors: fetchErrors } = await provider.getSecretValues(secretRefs);
 
-      // TODO@nafees: Handle null values
-      // @ts-ignore
-      await provider.setSecrets(secrets.map((s) => ({ value: s })));
+      const perSecretErrors: SecretFetchError[] = fetchErrors.map((e) => ({
+        secretRefId: e.ref.id,
+        message: e.message,
+      }));
 
-      return { type: "success", data: secrets };
+      const successSecrets: SecretValue[] = [];
+      for (const s of results) {
+        if (!s) continue;
+        const hasEmptyValue =
+          (s.type === SecretProviderType.AWS_SECRETS_MANAGER && !s.value);
+        if (hasEmptyValue) {
+          perSecretErrors.push({ secretRefId: s.secretReference.id, message: "Secret value is empty" });
+          continue;
+        }
+        successSecrets.push(s);
+      }
+
+      await provider.setSecrets(successSecrets.map((s) => ({ value: s })));
+
+      return { type: "success", data: { secrets: successSecrets, errors: perSecretErrors } };
     } catch (error) {
       return createSecretsError(
         SecretsErrorCode.SECRET_FETCH_FAILED,

--- a/src/lib/secretsManager/secretsManager.ts
+++ b/src/lib/secretsManager/secretsManager.ts
@@ -1,4 +1,5 @@
 import {
+  AwsSecretValue,
   SecretProviderConfig,
   SecretProviderMetadata,
   SecretReference,
@@ -162,7 +163,7 @@ export class SecretsManager {
           { providerId }
         );
       }
-      const secretValue = await provider.getSecret(ref);
+      const secretValue = await provider.getSecretValue(ref);
       return { type: "success", data: secretValue };
     } catch (error) {
       return createSecretsError(
@@ -201,7 +202,7 @@ export class SecretsManager {
           );
         }
 
-        const secretValues = await provider.getSecrets(refs);
+        const secretValues = await provider.getSecretValues(refs);
         results.push(
           ...secretValues.filter((sv): sv is SecretValue => sv !== null)
         );
@@ -282,8 +283,9 @@ export class SecretsManager {
     return { type: "success" };
   }
 
-  async refreshSecrets(
-    providerId: string
+  async fetchAndSaveSecrets(
+    providerId: string,
+    secretRefs: SecretReference[]
   ): SecretsResultPromise<(SecretValue | null)[]> {
     try {
       const provider = this.registry.getProvider(providerId);
@@ -296,7 +298,11 @@ export class SecretsManager {
         );
       }
 
-      const secrets = await provider.refreshSecrets();
+      const secrets = await provider.getSecretValues(secretRefs)
+
+      // TODO@nafees: Handle null values
+      // @ts-ignore
+      await provider.setSecrets(secrets.map((s) => ({ value: s })));
 
       return { type: "success", data: secrets };
     } catch (error) {
@@ -328,5 +334,26 @@ export class SecretsManager {
 
   onProvidersChange(callback: ProviderChangeCallback): () => void {
     return this.registry.onProvidersChange(callback);
+  }
+
+  async listSecrets(providerId: string): SecretsResultPromise<SecretValue[]> {
+    try {
+      const provider = this.registry.getProvider(providerId);
+      if (!provider) {
+        return createSecretsError(
+          SecretsErrorCode.PROVIDER_NOT_FOUND,
+          `Provider with id ${providerId} not found`,
+          { providerId }
+        );
+      }
+      const secrets = await provider.listAllSecrets();
+      return { type: "success", data: secrets };
+    } catch (error) {
+      return createSecretsError(
+        SecretsErrorCode.STORAGE_READ_FAILED,
+        error instanceof Error ? error.message : "Failed to list secrets",
+        { providerId, cause: error as Error }
+      );
+    }
   }
 }

--- a/src/lib/storage/EncryptedElectronStore.ts
+++ b/src/lib/storage/EncryptedElectronStore.ts
@@ -99,6 +99,14 @@ export class EncryptedElectronStore {
     });
   }
 
+  onKeyChange<T>(subKey: string, callback: (_data: T) => void): () => void {
+    return this.store.onDidChange(`data.${subKey}` as keyof EncryptedStoreSchema, (newValue) => {
+      if (newValue !== undefined) {
+        callback(newValue as T);
+      }
+    });
+  }
+
   getStore(): Store<EncryptedStoreSchema> {
     return this.store;
   }

--- a/src/main/events.js
+++ b/src/main/events.js
@@ -24,12 +24,13 @@ import { createOrUpdateAxiosInstance } from "./actions/getProxiedAxios";
 // eslint-disable-next-line import/no-cycle
 import createTrayMenu, { loadWebAppUrl } from "./main";
 import {
+  fetchAndSaveSecrets,
   getSecretProviderConfig,
   getSecretValue,
   getSecretValues,
   initSecretsManager,
   listSecretProviders,
-  refreshSecrets,
+  listSecrets,
   removeSecretProviderConfig,
   removeSecretValue,
   removeSecretValues,
@@ -362,8 +363,8 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
     return getSecretValues(secrets);
   });
 
-  ipcMain.handle("secretsManager:refreshSecrets", (event, { providerId }) => {
-    return refreshSecrets(providerId);
+  ipcMain.handle("secretsManager:fetchAndSaveSecrets", (event, { providerId, secretRefs }) => {
+    return fetchAndSaveSecrets(providerId, secretRefs);
   });
 
   ipcMain.handle("secretsManager:listSecretProviders", () => {
@@ -379,6 +380,10 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
 
   ipcMain.handle("secretsManager:removeSecretValues", (event, { secrets }) => {
     return removeSecretValues(secrets);
+  });
+
+  ipcMain.handle("secretsManager:listSecrets", (event, { providerId }) => {
+    return listSecrets(providerId);
   });
 };
 

--- a/src/main/events.js
+++ b/src/main/events.js
@@ -31,6 +31,8 @@ import {
   listSecretProviders,
   refreshSecrets,
   removeSecretProviderConfig,
+  removeSecretValue,
+  removeSecretValues,
   setSecretProviderConfig,
   subscribeToProvidersChange,
   testSecretProviderConnection,
@@ -301,8 +303,8 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
     webAppWindow?.send("helper-server-hit");
   });
 
-  ipcMain.handle("secretsManager:init", () => {
-    return initSecretsManager();
+  ipcMain.handle("secretsManager:init", (event, { userId }) => {
+    return initSecretsManager(userId);
   });
 
   ipcMain.handle("secretsManager:subscribeToProvidersChange", () => {
@@ -366,6 +368,17 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
 
   ipcMain.handle("secretsManager:listSecretProviders", () => {
     return listSecretProviders();
+  });
+
+  ipcMain.handle(
+    "secretsManager:removeSecretValue",
+    (event, { providerId, secretReference }) => {
+      return removeSecretValue(providerId, secretReference);
+    }
+  );
+
+  ipcMain.handle("secretsManager:removeSecretValues", (event, { secrets }) => {
+    return removeSecretValues(secrets);
   });
 };
 


### PR DESCRIPTION
1. removes inmemory caching and adds file persistant caching
2. bind the config to a userId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add remove single/batch secret operations and provider-specific secret listing
  * Introduce fetch-and-save flow for retrieving and persisting secrets with per-secret error details

* **Refactor**
  * Initialization now requires a user ID (per-user secret stores)
  * Move from in-memory refresh/cache to persistent, storage-backed secret management and more granular provider/secret APIs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->