### PR TITLE
[RQ-737]: Skip SSL Verification

### DIFF
--- a/src/main/actions/getProxiedAxios.ts
+++ b/src/main/actions/getProxiedAxios.ts
@@ -90,24 +90,8 @@ function createAxiosInstance(
         ca: readFileSync(config.rootCertPath),
       }),
     });
-
-    // Interceptor to disable SSL securely when Proxy is enabled
-    instance.interceptors.request.use((requestConfig: any) => {
-      if (requestConfig.sslVerificationDisabled) {
-        requestConfig.httpsAgent = new PatchedHttpsProxyAgent({
-          host: config.ip,
-          port: config.port,
-          ca: readFileSync(config.rootCertPath),
-          rejectUnauthorized: false,
-        });
-      }
-      return requestConfig;
-    });
-
   } else {
-    instance = axios.create({
-      proxy: false,
-    });
+    instance = axios.create({ proxy: false });
 
     instance.interceptors.request.use(async (requestConfig: any) => {
       const { url: requestUrl, sslVerificationDisabled } = requestConfig;
@@ -118,23 +102,22 @@ function createAxiosInstance(
 
       const url = new URL(requestUrl);
       const { hostname, port: urlPort, protocol } = url;
+      const port = urlPort ? parseInt(urlPort, 10) : (protocol === "https:" ? 443 : 80);
 
-      const isLocalhost = hostname === "localhost"
+      const isLocalhost = hostname === "localhost" 
         || hostname === LOCAL_IPV4
         || hostname === `[${LOCAL_IPV6}]`
         || hostname === LOCAL_UNSPECIFIED;
 
       if (isLocalhost) {
-        const port = urlPort ? parseInt(urlPort, 10) : protocol === "https:" ? 443 : 80;
-
         const lookup = await createLocalhostLookup(port);
-        requestConfig.httpAgent = new http.Agent({ lookup });
-        
-        // Preserve SSL bypass flag alongside localhost lookup logic
-        requestConfig.httpsAgent = new https.Agent({ 
+        const agentOptions = {
           lookup,
-          rejectUnauthorized: !sslVerificationDisabled
-        });
+          rejectUnauthorized: sslVerificationDisabled !== true,
+        };
+
+        requestConfig.httpAgent = new http.Agent({ lookup });
+        requestConfig.httpsAgent = new https.Agent(agentOptions);
 
         // Node.js skips DNS lookup for raw IP literals, so the custom lookup
         // above has no effect. Rewrite the URL to the concrete working IP.
@@ -147,7 +130,7 @@ function createAxiosInstance(
           }
         }
       } else if (sslVerificationDisabled) {
-        // Handle standard web requests where SSL is bypassed
+          // Handle standard web requests where SSL is bypassed
         requestConfig.httpsAgent = new https.Agent({ rejectUnauthorized: false });
       }
 

--- a/src/main/actions/getProxiedAxios.ts
+++ b/src/main/actions/getProxiedAxios.ts
@@ -90,13 +90,27 @@ function createAxiosInstance(
         ca: readFileSync(config.rootCertPath),
       }),
     });
+
+    // Interceptor to disable SSL securely when Proxy is enabled
+    instance.interceptors.request.use((requestConfig: any) => {
+      if (requestConfig.sslVerificationDisabled) {
+        requestConfig.httpsAgent = new PatchedHttpsProxyAgent({
+          host: config.ip,
+          port: config.port,
+          ca: readFileSync(config.rootCertPath),
+          rejectUnauthorized: false,
+        });
+      }
+      return requestConfig;
+    });
+
   } else {
     instance = axios.create({
       proxy: false,
     });
 
-    instance.interceptors.request.use(async (requestConfig) => {
-      const { url: requestUrl } = requestConfig;
+    instance.interceptors.request.use(async (requestConfig: any) => {
+      const { url: requestUrl, sslVerificationDisabled } = requestConfig;
 
       if (!requestUrl) {
         return requestConfig;
@@ -115,7 +129,12 @@ function createAxiosInstance(
 
         const lookup = await createLocalhostLookup(port);
         requestConfig.httpAgent = new http.Agent({ lookup });
-        requestConfig.httpsAgent = new https.Agent({ lookup });
+        
+        // Preserve SSL bypass flag alongside localhost lookup logic
+        requestConfig.httpsAgent = new https.Agent({ 
+          lookup,
+          rejectUnauthorized: !sslVerificationDisabled
+        });
 
         // Node.js skips DNS lookup for raw IP literals, so the custom lookup
         // above has no effect. Rewrite the URL to the concrete working IP.
@@ -127,6 +146,9 @@ function createAxiosInstance(
             requestConfig.url = requestUrl.replace(hostname, targetIp);
           }
         }
+      } else if (sslVerificationDisabled) {
+        // Handle standard web requests where SSL is bypassed
+        requestConfig.httpsAgent = new https.Agent({ rejectUnauthorized: false });
       }
 
       return requestConfig;
@@ -164,7 +186,7 @@ export const createOrUpdateAxiosInstance = (
 };
 
 /* 
-  [Intentional] add cookies by default. In line with emulating browser behaviour.
+[Intentional] add cookies by default. In line with emulating browser behaviour.
   A better name could be excludeCredentials=false .
   did this because a flag called `withCredentials` has now been released for extension
 */

--- a/src/main/actions/getProxiedAxios.ts
+++ b/src/main/actions/getProxiedAxios.ts
@@ -113,7 +113,7 @@ function createAxiosInstance(
         const lookup = await createLocalhostLookup(port);
         const agentOptions = {
           lookup,
-          rejectUnauthorized: sslVerificationDisabled !== true,
+          rejectUnauthorized: sslVerificationDisabled !== true, // false = skip SSL verification, true = enforce certificate validation
         };
 
         requestConfig.httpAgent = new http.Agent({ lookup });

--- a/src/main/actions/makeApiClientRequest.js
+++ b/src/main/actions/makeApiClientRequest.js
@@ -108,6 +108,8 @@ const makeApiClientRequest = async ({ apiRequest }) => {
       validateStatus: () => {
         return true;
       },
+      // Pass the SSL flag down for the interceptor to handle
+      sslVerificationDisabled: apiRequest.sslVerificationDisabled,
     });
     const responseTime = performance.now() - requestStartTime;
 

--- a/src/main/actions/makeApiClientRequest.js
+++ b/src/main/actions/makeApiClientRequest.js
@@ -109,7 +109,7 @@ const makeApiClientRequest = async ({ apiRequest }) => {
         return true;
       },
       // Pass the SSL flag down for the interceptor to handle
-      sslVerificationDisabled: apiRequest.sslVerificationDisabled,
+      sslVerificationDisabled: apiRequest.sslVerificationDisabled === true,
     });
     const responseTime = performance.now() - requestStartTime;
 


### PR DESCRIPTION
https://browserstack.atlassian.net/browse/RQ-737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to disable SSL certificate verification for API requests.
  * Improved handling of connections when SSL verification is disabled, with special-case behavior for localhost addresses and adjusted handling for external hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->