### PR TITLE
[RQ-1116]: Failed to initialize FsManage : Could not load config 

### DIFF
--- a/src/renderer/actions/local-sync/fs-manager.ts
+++ b/src/renderer/actions/local-sync/fs-manager.ts
@@ -134,16 +134,23 @@ export class FsManager {
     });
     const rawConfig = readFileSync(configFile.path);
     
-    // If config file doesn't exist, return a default config
+    // Only return a default config if the error is ENOENT (file not found)
     if (rawConfig.type === "error") {
-      console.log(
-        `Could not load config from ${CONFIG_FILE}. ${rawConfig.error.message} Using default configuration.`
-      );
-      const defaultConfig: Static<typeof Config> = {
-        version: WORKSPACE_CONFIG_FILE_VERSION,
-        exclude: [],
-      };
-      return defaultConfig;
+      if (rawConfig.error && rawConfig.error.code === ErrorCode.NotFound) {
+        console.log(
+          `Config file not found at ${configFile.path}. Using default configuration.`
+        );
+        const defaultConfig: Static<typeof Config> = {
+          version: WORKSPACE_CONFIG_FILE_VERSION,
+          exclude: [],
+        };
+        return defaultConfig;
+      } else {
+        // For any other error (e.g., permission denied), rethrow
+        throw new Error(
+          `Could not load config from ${CONFIG_FILE}. ${rawConfig.error.message}`
+        );
+      }
     }
     const parsedConfig = parseJsonContent(rawConfig.content, Config);
     if (parsedConfig.type === "error") {

--- a/src/renderer/actions/local-sync/fs-manager.ts
+++ b/src/renderer/actions/local-sync/fs-manager.ts
@@ -133,10 +133,17 @@ export class FsManager {
       type: "file",
     });
     const rawConfig = readFileSync(configFile.path);
+    
+    // If config file doesn't exist, return a default config
     if (rawConfig.type === "error") {
-      throw new Error(
-        `Could not load config from ${CONFIG_FILE}. ${rawConfig.error.message}`
+      console.log(
+        `Could not load config from ${CONFIG_FILE}. ${rawConfig.error.message} Using default configuration.`
       );
+      const defaultConfig: Static<typeof Config> = {
+        version: WORKSPACE_CONFIG_FILE_VERSION,
+        exclude: [],
+      };
+      return defaultConfig;
     }
     const parsedConfig = parseJsonContent(rawConfig.content, Config);
     if (parsedConfig.type === "error") {


### PR DESCRIPTION

Uploading Screen Recording 2026-03-30 at 10.12.17 AM.mov…

Ticket: https://browserstack.atlassian.net/browse/RQ-1116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration file read failures: when the config file is missing the app logs the situation and continues using sensible defaults instead of aborting. Other file read errors still surface as errors. Malformed JSON in config continues to be reported as a parsing error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->