### PR TITLE
feat(signing): migrate Windows codesigning to Google Cloud KMS (26.6.3)

### DIFF
--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -1,5 +1,15 @@
 name: Release Desktop App
 
+# Single-job release flow preserved from the original samuelmeuli-based
+# pipeline. Mac + Linux behave exactly as before. The ONLY change is how
+# Windows installers get codesigned: the previous P12-via-secrets flow
+# (windows_certs / windows_certs_password) is replaced by Google Cloud KMS
+# signing via electron-builder's win.sign hook (scripts/windows-kms-sign.js).
+# The private key never leaves GCP; the public leaf cert is handed in via
+# the WINDOWS_CODESIGN_CERT_BASE64 secret. Everything else — `release: true`
+# uploading to GitHub Releases per the build.publish config, mac_certs for
+# macOS signing, Sentry sourcemap upload — is unchanged.
+
 on:
   workflow_dispatch:
     inputs:
@@ -15,6 +25,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write     # samuelmeuli uses github_token to publish releases
+      id-token: write     # OIDC for GCP Workload Identity Federation (Windows)
     env:
       EP_GH_IGNORE_TIME: true
       # APPLE_ID: ${{ secrets.apple_id }}
@@ -30,24 +43,96 @@ jobs:
       - name: EOL autocrlf true
         if: ${{ github.event.inputs.build_type == 'windows-2019' }}
         run: git config --global core.autocrlf true
-      - name: Install Distutils
-        if: ${{ github.event.inputs.build_type == 'windows-latest' }}
-        run: python -m pip install --upgrade setuptools
+
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 20.9.0
 
+      # Replaces the legacy `Install Distutils` step. node-gyp@9.3.1 (the
+      # legacy app's pinned version) still imports distutils.version, which
+      # Python 3.12+ removed (PEP 632). Pinning Python to 3.11 brings
+      # distutils back as stdlib for both windows-latest and ubuntu-latest
+      # runners.
+      - name: Set up Python 3.11 for node-gyp
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install desktop app dependencies
         run: bash ./install.sh
+
+      # ─── Windows: GCP KMS signing setup (replaces windows_certs P12) ────
+      # Runs only on windows-latest. The MSI + config drop is required so
+      # signtool can use the "Google Cloud KMS Provider" CSP from the
+      # win.sign hook later in the build step.
+      - name: Auth to Google Cloud (KMS)
+        if: ${{ github.event.inputs.build_type == 'windows-latest' }}
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
+
+      - name: Install + configure KMS CNG provider
+        if: ${{ github.event.inputs.build_type == 'windows-latest' }}
+        shell: pwsh
+        env:
+          GCP_PROJECT_ID: ${{ vars.WIN_SIGN_KMS_PROJECT }}
+          GCP_KMS_LOCATION: ${{ vars.WIN_SIGN_KMS_LOCATION }}
+          GCP_KMS_KEY_RING: ${{ vars.WIN_SIGN_KMS_KEY_RING }}
+          GCP_KMS_KEY_NAME: ${{ vars.WIN_SIGN_KMS_KEY_NAME }}
+          GCP_KMS_KEY_VERSION: ${{ vars.WIN_SIGN_KMS_KEY_VERSION }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # --- Install MSI ---
+          $cngVersion = '1.3'
+          $expectedHash = '4CB9FBF6F17F58CA1B404BF532C2D75519F5B3378F646B9C3AC4361E640F2450'
+          $cngUrl = "https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/cng-v${cngVersion}/kmscng-${cngVersion}-windows-amd64.zip"
+
+          Invoke-WebRequest -Uri $cngUrl -OutFile kmscng.zip
+          $actualHash = (Get-FileHash -Path kmscng.zip -Algorithm SHA256).Hash
+          if ($actualHash -ne $expectedHash) {
+            throw "CNG checksum mismatch — expected $expectedHash, got $actualHash"
+          }
+
+          Expand-Archive -Path kmscng.zip -DestinationPath kmscng
+          $msi = Get-ChildItem -Path kmscng -Filter '*.msi' -Recurse | Select-Object -First 1
+          if (-not $msi) { throw 'No MSI in extracted kmscng archive' }
+
+          $proc = Start-Process msiexec.exe -Wait -PassThru `
+            -ArgumentList "/i `"$($msi.FullName)`" /quiet /norestart"
+          if ($proc.ExitCode -ne 0) { throw "MSI install failed (exit $($proc.ExitCode))" }
+
+          # --- Write the CNG key-path config ---
+          $required = @('GCP_PROJECT_ID','GCP_KMS_LOCATION','GCP_KMS_KEY_RING','GCP_KMS_KEY_NAME','GCP_KMS_KEY_VERSION')
+          foreach ($v in $required) {
+            if (-not [Environment]::GetEnvironmentVariable($v)) { throw "Missing required variable: $v" }
+          }
+          $keyPath = "projects/$env:GCP_PROJECT_ID/locations/$env:GCP_KMS_LOCATION/keyRings/$env:GCP_KMS_KEY_RING/cryptoKeys/$env:GCP_KMS_KEY_NAME/cryptoKeyVersions/$env:GCP_KMS_KEY_VERSION"
+
+          $configDir = 'C:\Windows\KMSCNG'
+          New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+          "resources:`n  - crypto_key_version: `"$keyPath`"" |
+            Out-File -Encoding utf8NoBOM -FilePath "$configDir\config.yaml"
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1.6.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # ─── Windows GCP KMS signing (consumed by scripts/windows-kms-sign.js) ──
+          # On non-Windows builds these resolve to empty / are unused; the
+          # sign script self-skips when USE_KMS_SIGNING is not 'true'.
+          USE_KMS_SIGNING: ${{ github.event.inputs.build_type == 'windows-latest' && 'true' || '' }}
+          WIN_SIGN_CERT_BASE64: ${{ secrets.WINDOWS_CODESIGN_CERT_BASE64 }}
+          GCP_PROJECT_ID: ${{ vars.WIN_SIGN_KMS_PROJECT }}
+          GCP_KMS_LOCATION: ${{ vars.WIN_SIGN_KMS_LOCATION }}
+          GCP_KMS_KEY_RING: ${{ vars.WIN_SIGN_KMS_KEY_RING }}
+          GCP_KMS_KEY_NAME: ${{ vars.WIN_SIGN_KMS_KEY_NAME }}
+          GCP_KMS_KEY_VERSION: ${{ vars.WIN_SIGN_KMS_KEY_VERSION }}
         with:
           # GitHub token, automatically provided to the action
           # (No need to define this secret in the repo settings)
@@ -57,8 +142,12 @@ jobs:
           mac_certs: ${{ secrets.mac_certs }}
           mac_certs_password: ${{ secrets.mac_certs_password }}
 
-          windows_certs: ${{ secrets.windows_certs }}
-          windows_certs_password: ${{ secrets.windows_certs_password }}
+          # windows_certs / windows_certs_password intentionally removed.
+          # Windows codesigning now happens inside electron-builder via the
+          # win.sign hook (scripts/windows-kms-sign.js) using the GCP KMS CNG
+          # provider — the private key never lands on the runner. The hook
+          # reads USE_KMS_SIGNING / WIN_SIGN_CERT_BASE64 / GCP_KMS_* from the
+          # env block above.
 
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "26.3.3",
+  "version": "26.5.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "26.3.3",
+      "version": "26.5.28",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -14,7 +14,7 @@
         "@devicefarmer/adbkit": "^3.2.6",
         "@electron/remote": "^2.1.2",
         "@requestly/requestly-core": "1.1.1",
-        "@requestly/requestly-proxy": "1.3.13",
+        "@requestly/requestly-proxy": "1.4.0",
         "@sentry/browser": "^8.34.0",
         "@sentry/electron": "^5.6.0",
         "@sinclair/typebox": "^0.34.25",
@@ -3407,9 +3407,10 @@
       "integrity": "sha512-/1Kj71UGT5ojK2y+UWxpbX3WLNt+mLlXi6Jd7gK48MeEXrZqlrkWYIPaGIHxhbg2UdADVawfDeOv69ns6cmuMQ=="
     },
     "node_modules/@requestly/requestly-proxy": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.13.tgz",
-      "integrity": "sha512-4B2t2vU3aETolhSYtLgADZt1M4hnZ9H2f0/sDLljCmxl5WHl0EagF05EFGjheYMx+/sGAGj7L2u6c4GyrvIJnw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.4.0.tgz",
+      "integrity": "sha512-9ZDNe6q6z117ndPOMDf5o5uZadzXU61sbJW77CBjmGQ7e+UozgxFToA8UcB85YEP/thZjpEugboK5E3FPX61dQ==",
+      "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "1.1.1",
         "@sentry/browser": "^8.33.1",
@@ -21505,9 +21506,9 @@
       "integrity": "sha512-/1Kj71UGT5ojK2y+UWxpbX3WLNt+mLlXi6Jd7gK48MeEXrZqlrkWYIPaGIHxhbg2UdADVawfDeOv69ns6cmuMQ=="
     },
     "@requestly/requestly-proxy": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.3.13.tgz",
-      "integrity": "sha512-4B2t2vU3aETolhSYtLgADZt1M4hnZ9H2f0/sDLljCmxl5WHl0EagF05EFGjheYMx+/sGAGj7L2u6c4GyrvIJnw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.4.0.tgz",
+      "integrity": "sha512-9ZDNe6q6z117ndPOMDf5o5uZadzXU61sbJW77CBjmGQ7e+UozgxFToA8UcB85YEP/thZjpEugboK5E3FPX61dQ==",
       "requires": {
         "@requestly/requestly-core": "1.1.1",
         "@sentry/browser": "^8.33.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "26.5.28",
+  "version": "26.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "26.5.28",
+      "version": "26.6.3",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.5.28",
+  "version": "26.6.3",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.3.3",
+  "version": "26.5.28",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
@@ -118,6 +118,11 @@
       ]
     },
     "win": {
+      "signingHashAlgorithms": [
+        "sha256"
+      ],
+      "publisherName": "BrowserStack, Inc.",
+      "sign": "./scripts/windows-kms-sign.js",
       "target": [
         "nsis"
       ]
@@ -276,7 +281,7 @@
     "@devicefarmer/adbkit": "^3.2.6",
     "@electron/remote": "^2.1.2",
     "@requestly/requestly-core": "1.1.1",
-    "@requestly/requestly-proxy": "1.3.13",
+    "@requestly/requestly-proxy": "1.4.0",
     "@sentry/browser": "^8.34.0",
     "@sentry/electron": "^5.6.0",
     "@sinclair/typebox": "^0.34.25",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.3.3",
+  "version": "26.5.28",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.5.28",
+  "version": "26.6.3",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",

--- a/scripts/windows-kms-sign.js
+++ b/scripts/windows-kms-sign.js
@@ -1,0 +1,199 @@
+/**
+ * Custom Windows code signing script for electron-builder.
+ *
+ * Invoked by electron-builder via `signtoolOptions.sign` for each file
+ * that needs an Authenticode signature. Uses Google Cloud KMS as the HSM
+ * backend via the Windows CNG provider — the private key never leaves GCP.
+ *
+ * Requires:
+ *   - Google Cloud KMS CNG Provider installed on the build machine
+ *   - GCP authentication (GOOGLE_APPLICATION_CREDENTIALS set by WIF)
+ *   - Environment variables: USE_KMS_SIGNING, GCP_PROJECT_ID, GCP_KMS_LOCATION,
+ *     GCP_KMS_KEY_RING, GCP_KMS_KEY_NAME, GCP_KMS_KEY_VERSION
+ *   - Public leaf certificate, supplied at runtime via *one* of:
+ *       - WIN_SIGN_CERT_PATH    — path to an existing .crt file
+ *       - WIN_SIGN_CERT_BASE64  — base64-encoded cert bytes; decoded to a
+ *                                 temp file by this script
+ *     The cert is NEVER stored in source control; the CI workflow hands it
+ *     in from a GitHub secret. The private key for this cert lives in GCP
+ *     KMS.
+ */
+
+const { execFile } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// signtool requires HTTP for RFC 3161 timestamp URLs (HTTPS is not supported)
+const TIMESTAMP_URL = 'http://timestamp.sectigo.com';
+
+const REQUIRED_ENV_VARS = [
+  'GCP_PROJECT_ID',
+  'GCP_KMS_LOCATION',
+  'GCP_KMS_KEY_RING',
+  'GCP_KMS_KEY_NAME',
+  'GCP_KMS_KEY_VERSION',
+];
+
+const MAX_RETRIES = 2;
+const RETRY_DELAY_MS = 5000;
+
+// Resolve the codesign leaf cert at sign time from env. Two acceptable shapes:
+//   1. WIN_SIGN_CERT_PATH points to an already-on-disk .crt
+//   2. WIN_SIGN_CERT_BASE64 holds the cert bytes; we materialise them to a
+//      runner-temp file. Decoding more than once (the hook fires per signed
+//      binary) is harmless — same bytes, same path.
+function getCertPath() {
+  if (process.env.WIN_SIGN_CERT_PATH) {
+    return process.env.WIN_SIGN_CERT_PATH;
+  }
+  if (process.env.WIN_SIGN_CERT_BASE64) {
+    const tempPath = path.join(os.tmpdir(), 'windows-codesign.crt');
+    if (!fs.existsSync(tempPath)) {
+      fs.writeFileSync(tempPath, Buffer.from(process.env.WIN_SIGN_CERT_BASE64, 'base64'));
+    }
+    return tempPath;
+  }
+  throw new Error(
+    'Windows codesign cert missing — set WIN_SIGN_CERT_PATH or WIN_SIGN_CERT_BASE64.',
+  );
+}
+
+function getKmsKeyPath() {
+  return [
+    'projects',
+    process.env.GCP_PROJECT_ID,
+    'locations',
+    process.env.GCP_KMS_LOCATION,
+    'keyRings',
+    process.env.GCP_KMS_KEY_RING,
+    'cryptoKeys',
+    process.env.GCP_KMS_KEY_NAME,
+    'cryptoKeyVersions',
+    process.env.GCP_KMS_KEY_VERSION,
+  ].join('/');
+}
+
+function findSigntool() {
+  const kitsRoot = 'C:\\Program Files (x86)\\Windows Kits\\10\\bin';
+  if (!fs.existsSync(kitsRoot)) {
+    throw new Error(`Windows SDK not found at ${kitsRoot}`);
+  }
+
+  const versions = fs
+    .readdirSync(kitsRoot)
+    .filter((d) => d.startsWith('10.'))
+    .sort()
+    .reverse();
+
+  for (const version of versions) {
+    const candidate = path.join(kitsRoot, version, 'x64', 'signtool.exe');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`signtool.exe not found in ${kitsRoot}. Is the Windows SDK installed?`);
+}
+
+function validateEnv() {
+  const missing = REQUIRED_ENV_VARS.filter((v) => !process.env[v]);
+  if (missing.length > 0) {
+    throw new Error(`KMS signing enabled but missing environment variables: ${missing.join(', ')}`);
+  }
+}
+
+function validateCert(certPath) {
+  if (!fs.existsSync(certPath)) {
+    throw new Error(
+      `Signing certificate not found at ${certPath}. ` +
+        'Workflow should provide it via WIN_SIGN_CERT_BASE64 (preferred) or WIN_SIGN_CERT_PATH.',
+    );
+  }
+}
+
+function runSigntool(signtoolPath, args) {
+  return new Promise((resolve, reject) => {
+    execFile(signtoolPath, args, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`signtool failed (exit ${error.code}):\nstdout: ${stdout}\nstderr: ${stderr}`));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @param {import('electron-builder').CustomWindowsSignTaskConfiguration} configuration
+ * @returns {Promise<void>}
+ */
+async function sign(configuration) {
+  // Skip signing when KMS is not enabled (local dev, macOS/Linux CI)
+  if (process.env.USE_KMS_SIGNING !== 'true') {
+    return;
+  }
+
+  validateEnv();
+
+  const certPath = getCertPath();
+  validateCert(certPath);
+
+  const signtoolPath = findSigntool();
+  const kmsKeyPath = getKmsKeyPath();
+
+  const args = buildSigntoolArgs(certPath, kmsKeyPath, configuration.path);
+
+  let lastError;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await runSigntool(signtoolPath, args);
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt < MAX_RETRIES) {
+        console.warn(`signtool attempt ${attempt + 1} failed, retrying in ${RETRY_DELAY_MS}ms...`);
+        await sleep(RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+exports.default = sign;
+
+/**
+ * Build the signtool argument array. Extracted as a pure function for testability.
+ */
+function buildSigntoolArgs(certPath, kmsKeyPath, filePath) {
+  return [
+    'sign',
+    '/fd',
+    'sha256',
+    '/tr',
+    TIMESTAMP_URL,
+    '/td',
+    'sha256',
+    '/f',
+    certPath,
+    '/csp',
+    'Google Cloud KMS Provider',
+    '/kc',
+    kmsKeyPath,
+    filePath,
+  ];
+}
+
+// Exported for testing
+exports._internals = {
+  getCertPath,
+  getKmsKeyPath,
+  validateEnv,
+  buildSigntoolArgs,
+  REQUIRED_ENV_VARS,
+};

--- a/scripts/windows-kms-sign.js
+++ b/scripts/windows-kms-sign.js
@@ -37,6 +37,12 @@ const REQUIRED_ENV_VARS = [
 
 const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 5000;
+// Hard upper bound per signtool invocation. A normal sign is sub-second;
+// transient KMS / timestamp-server stalls can push it to ~30s. 5 min gives
+// slow paths room while bounding pathological hangs so the retry loop in
+// sign() actually gets a chance to run. Without this, a hung child blocks
+// execFile forever and retries never fire.
+const SIGNTOOL_TIMEOUT_MS = 5 * 60 * 1000;
 
 // Resolve the codesign leaf cert at sign time from env. Two acceptable shapes:
 //   1. WIN_SIGN_CERT_PATH points to an already-on-disk .crt
@@ -114,9 +120,15 @@ function validateCert(certPath) {
 
 function runSigntool(signtoolPath, args) {
   return new Promise((resolve, reject) => {
-    execFile(signtoolPath, args, (error, stdout, stderr) => {
+    execFile(signtoolPath, args, { timeout: SIGNTOOL_TIMEOUT_MS, windowsHide: true }, (error, stdout, stderr) => {
       if (error) {
-        reject(new Error(`signtool failed (exit ${error.code}):\nstdout: ${stdout}\nstderr: ${stderr}`));
+        // When Node's `timeout` kicks in it kills the child with SIGTERM,
+        // surfacing error.killed === true rather than ETIMEDOUT. Distinguish
+        // that case so the retry loop's surfaced reason is honest.
+        const reason = error.killed
+          ? `signtool timed out after ${SIGNTOOL_TIMEOUT_MS}ms (signal: ${error.signal || 'SIGTERM'})`
+          : `signtool failed (exit ${error.code})`;
+        reject(new Error(`${reason}:\nstdout: ${stdout}\nstderr: ${stderr}`));
         return;
       }
       resolve(stdout);


### PR DESCRIPTION
## Summary

Replaces the **Windows** P12-via-secret signing path (`samuelmeuli` action's `windows_certs` / `windows_certs_password`) with **Google Cloud KMS** Authenticode signing. **macOS, Linux, and the GitHub Releases publish flow are unchanged** — this is a targeted swap of just the Windows key-fetching mechanism.

Also includes a version bump to \`26.6.3\` and a \`@requestly/requestly-proxy\` bump (\`1.3.13\` → \`1.4.0\`).

## Windows signing change

| Aspect | Before | After |
|---|---|---|
| Cert + private key | Both in \`secrets.windows_certs\` (base64 P12) | **Cert**: \`secrets.WINDOWS_CODESIGN_CERT_BASE64\` (public only). **Key**: Google Cloud KMS |
| Sign mechanism | \`samuelmeuli\` action passes P12 to electron-builder, which calls signtool | electron-builder calls \`scripts/windows-kms-sign.js\` (new \`win.sign\` hook), which invokes signtool with the \`\"Google Cloud KMS Provider\"\` CSP |
| GCP auth | n/a | Workload Identity Federation (no SA keys in CI) |
| Private key on runner | yes (decoded P12 sits on disk during build) | **never** — only signature bytes come back from KMS |

## What stayed exactly as before (existing prod release process)

- \`samuelmeuli/action-electron-builder@v1.6.0\` orchestrating build + publish
- \`release: true\` → GitHub Releases via \`secrets.publish_token\`
- \`secrets.mac_certs\` / \`mac_certs_password\` for macOS signing
- \`mac.identity\` / \`mac.notarize: { teamId }\` for built-in notarytool
- \`publish.releaseType: \"release\"\` (immediate publish)
- Branch guard \`master\` || \`production\`
- Single-job per-dispatch \`build_type\` selector

## Workflow housekeeping (necessary, not stylistic)

- \`actions/checkout\` v2 → v4
- \`actions/setup-node\` v2 → v4
- \`Install Distutils\` step → \`actions/setup-python@v5\` pinning Python 3.11 (node-gyp 9.3.1 needs distutils; Python 3.12+ removed it and modern setuptools no longer ships a backport — without this the postinstall native-deps rebuild fails on the current windows-latest image)
- \`permissions: { contents: write, id-token: write }\` (contents was implicit via \`publish_token\`; id-token is the WIF requirement)

## Required repo settings before signed Windows dispatch

Existing secrets/vars stay as-is. Add for Windows KMS:

**Secret**: \`WINDOWS_CODESIGN_CERT_BASE64\` (base64 of public Authenticode leaf cert)

**Variables**:
- \`WIF_PROVIDER\` = \`projects/.../workloadIdentityPools/production-github-pool/providers/production-github-provider\`
- \`WIF_SERVICE_ACCOUNT\` = \`production-github-deploy-sa@requestly-api-client.iam.gserviceaccount.com\`
- \`WIN_SIGN_KMS_PROJECT\`, \`WIN_SIGN_KMS_LOCATION\`, \`WIN_SIGN_KMS_KEY_RING\`, \`WIN_SIGN_KMS_KEY_NAME\`, \`WIN_SIGN_KMS_KEY_VERSION\`

**GCP-side** (already done, verified live via gcloud): \`production-github-pool\` attribute_condition trusts \`requestly/requestly-desktop-app @ refs/heads/master\`; deploy SA has \`roles/cloudkms.signer\` on the key (same SA+key the api-client repo signs its own Windows builds with).

## Files changed

\`\`\`
.github/workflows/release_desktop_app.yml   +103 / -7
package.json                                  +9 / -2
package-lock.json                            +12 / -7
release/app/package.json                      +1 / -1
scripts/windows-kms-sign.js                   new file (sanitized header)
\`\`\`

## Test plan

- [ ] Add the listed secret + variables
- [ ] Dispatch from \`master\` with \`build_type: windows-latest\` and a \`v26.6.3\` tag → signed \`.exe\` published to a GitHub Release
- [ ] Verify: \`signtool verify /pa /v Requestly-Setup-26.6.3.exe\` → Sectigo chain, CN=\`BrowserStack, Inc.\`
- [ ] Dispatch \`ubuntu-latest\` → AppImage published unchanged

## Notes

- \`release/app/package-lock.json\` is intentionally untouched — \`electron-builder install-app-deps\` regenerates it on every CI run, and a version-only edit there caused a 3000-line lockfile-schema reformat that would have buried this PR's signal in noise.
- The signing approach has been dry-run successfully on \`requestly-desktop-dev\` and the \`dinex-dev/requestly-desktop-app\` fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * App version bumped to 26.6.3
  * Dependency `@requestly/requestly-proxy` upgraded to 1.4.0

* **New Features**
  * Windows desktop signing migrated to Google Cloud KMS-backed codesigning
  * Windows build now performs KMS provider installation and config for cloud signing
  * CI workflow updated to support OIDC-based cloud signing and new signing env vars
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
