### PR TITLE
fix: update GitHub repo references after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a rel="noreferrer noopener" href="https://requestly.io/">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/requestly/requestly-desktop-app/assets/16779465/84f8c853-81df-4ffc-94cb-40f0b1d122d6">
-      <source media="(prefers-color-scheme: light)" srcset="https://github.com/requestly/requestly-desktop-app/assets/16779465/ebadc791-4eb6-4faa-920a-a322aa4b892b">
-        <img alt="Requestly Logo" src="https://github.com/requestly/requestly-desktop-app/assets/16779465/84f8c853-81df-4ffc-94cb-40f0b1d122d6" width="40%">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/requestly/http-interceptor-desktop-app/assets/16779465/84f8c853-81df-4ffc-94cb-40f0b1d122d6">
+      <source media="(prefers-color-scheme: light)" srcset="https://github.com/requestly/http-interceptor-desktop-app/assets/16779465/ebadc791-4eb6-4faa-920a-a322aa4b892b">
+        <img alt="Requestly Logo" src="https://github.com/requestly/http-interceptor-desktop-app/assets/16779465/84f8c853-81df-4ffc-94cb-40f0b1d122d6" width="40%">
       </picture>
   </a>
 </p>
@@ -52,7 +52,7 @@ Npm (Version: 10.8.2)
 1. Clone the repo
 
 ```
-git clone https://github.com/requestly/requestly-desktop-app.git
+git clone https://github.com/requestly/http-interceptor-desktop-app.git
 ```
 
 2. Clone requestly-proxy. (Should be cloned in the same folder for development)

--- a/package.json
+++ b/package.json
@@ -153,12 +153,12 @@
       "provider": "github",
       "releaseType": "release",
       "owner": "requestly",
-      "repo": "requestly-desktop-app"
+      "repo": "http-interceptor-desktop-app"
     }
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/requestly/requestly-desktop-app.git"
+    "url": "git+https://github.com/requestly/http-interceptor-desktop-app.git"
   },
   "author": {
     "name": "BrowserStack Inc.",


### PR DESCRIPTION
## What
Updates two project-level files to reflect the GitHub repo rename from **`requestly/requestly-desktop-app`** → **`requestly/http-interceptor-desktop-app`**:

| File | Change |
|---|---|
| `package.json` `build.publish.repo` | `requestly-desktop-app` → `http-interceptor-desktop-app` — consumed by **electron-builder's publish step** to target the GitHub Releases API |
| `package.json` `repository.url` | Same rename — npm metadata, IDE tooling |
| `README.md` | 3 GitHub-hosted asset URLs + 1 `git clone` instruction |

Net diff: 2 files, +6 / −6.

## Why
Today's release dispatch surfaced the rename's residual fragility:
https://github.com/requestly/http-interceptor-desktop-app/actions/runs/26888111284

The error log shows electron-builder hitting **`api.github.com/repos/requestly/requestly-desktop-app/releases`** (the old URL) and getting 401 from GitHub.

⚠ **The 401 itself is NOT caused by this URL** — it's caused by an expired `PUBLISH_TOKEN` PAT (170+ days old, beyond GitHub's typical PAT lifetime). That has to be regenerated separately in repo Settings → Secrets and Variables → Actions.

This PR fixes the **adjacent, latent issue**: even after the PAT is refreshed, the publish URL still points at the old name. GitHub's REST API redirects most reads, but is inconsistent on write endpoints (release create + asset upload), and the misleading URL in error logs costs the next person's debugging time.

## Adjacent rename references not touched (deliberate)
- `electron-builder-setapp.json` `publish.repo` is set to `requestly-desktop-app-release` — a **separate** repo (Mac SetApp distribution variant). Whether that one was also renamed is unknown; left alone to keep this PR's scope clean. If it was renamed, a separate PR can mirror this one.
- The local `git remote get-url origin` still points at the old URL. GitHub's git transport handles redirects transparently (`git push`/`pull` work), so this is cosmetic on developer machines. Each contributor can update locally with `git remote set-url origin https://github.com/requestly/http-interceptor-desktop-app.git`.

## Verification + next steps
1. Merge this PR.
2. Regenerate the `PUBLISH_TOKEN` PAT (Settings → Developer settings → Personal access tokens) with `repo` scope (or fine-grained: Contents: Read+Write on this repo). Update the `PUBLISH_TOKEN` secret here.
3. Re-dispatch the **Release Desktop App** workflow. Expected: passes both auth gates (WIF for GCP + GitHub PAT for releases), creates the draft release.

## Related
- **WIF binding fix in infra repo**: https://github.com/requestly/requestly-api-client/pull/2409 — the *previous* failure on the same workflow was the WIF attribute condition rejecting the renamed repo's OIDC token. That fix lets the build progress; this PR fixes the publish step after the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository references and asset URLs in project documentation.

* **Chores**
  * Updated GitHub publishing configuration and repository metadata in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->