### PR TITLE
feat(macos): enable signed macOS builds in release workflow (26.6.8)

### DIFF
--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -148,8 +148,8 @@ jobs:
           github_token: ${{ secrets.publish_token }}
           package_root: "."
 
-          mac_certs: ${{ secrets.mac_certs }}
-          mac_certs_password: ${{ secrets.mac_certs_password }}
+          mac_certs: ${{ secrets.bstack_mac_certs }}
+          mac_certs_password: ${{ secrets.bstack_mac_certs_password }}
 
           # windows_certs / windows_certs_password intentionally removed.
           # Windows codesigning now happens inside electron-builder via the

--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -1,14 +1,20 @@
 name: Release Desktop App
 
 # Single-job release flow preserved from the original samuelmeuli-based
-# pipeline. Mac + Linux behave exactly as before. The ONLY change is how
-# Windows installers get codesigned: the previous P12-via-secrets flow
-# (windows_certs / windows_certs_password) is replaced by Google Cloud KMS
-# signing via electron-builder's win.sign hook (scripts/windows-kms-sign.js).
-# The private key never leaves GCP; the public leaf cert is handed in via
-# the WINDOWS_CODESIGN_CERT_BASE64 secret. Everything else — `release: true`
-# uploading to GitHub Releases per the build.publish config, mac_certs for
-# macOS signing, Sentry sourcemap upload — is unchanged.
+# pipeline. Each dispatch builds one platform; release tagging + GitHub
+# Releases upload are handled identically across all three (samuelmeuli's
+# `release: true` consumes the commit's version tag and uploads the
+# electron-builder outputs to the matching GH Release).
+#
+# Signing model:
+#   macOS    — Apple Developer ID via mac_certs (P12 in secrets.MAC_CERTS),
+#              electron-builder's built-in notarytool flow using
+#              APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD env (teamId hardcoded
+#              in package.json — public info anyway).
+#   Windows  — Authenticode via Google Cloud KMS (WIF + CNG provider +
+#              scripts/windows-kms-sign.js). Private key never leaves GCP;
+#              public leaf cert handed in via WINDOWS_CODESIGN_CERT_BASE64.
+#   Linux    — AppImage, unsigned.
 
 on:
   workflow_dispatch:
@@ -20,7 +26,7 @@ on:
         options:
           - ubuntu-latest
           - windows-latest
-          # - macos-latest
+          - macos-latest
         default: windows-latest
 
 jobs:
@@ -30,8 +36,11 @@ jobs:
       id-token: write     # OIDC for GCP Workload Identity Federation (Windows)
     env:
       EP_GH_IGNORE_TIME: true
-      # APPLE_ID: ${{ secrets.apple_id }}
-      # APPLE_ID_PASS: ${{ secrets.apple_id_pass }}
+      # Notarize credentials consumed by electron-builder's built-in
+      # notarytool flow during the macOS sign step. Empty on non-mac runs;
+      # the action then skips notarization cleanly.
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
 
     if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
     runs-on: ${{ github.event.inputs.build_type }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "26.6.3",
+  "version": "26.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "26.6.3",
+      "version": "26.6.8",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.6.3",
+  "version": "26.6.8",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",

--- a/package.json
+++ b/package.json
@@ -58,14 +58,12 @@
       {
         "ext": "har",
         "name": "Network Captures",
-        "role": "Default",
-        "icon": "assets/icon.icns"
+        "role": "Default"
       },
       {
         "ext": "rqly",
         "name": "Requestly session",
-        "role": "Owner",
-        "icon": "assets/icon.icns"
+        "role": "Owner"
       }
     ],
     "mac": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "26.3.3",
+  "version": "26.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "26.3.3",
+      "version": "26.6.8",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.6.3",
+  "version": "26.6.8",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
## Summary

Enables signed macOS builds in `release_desktop_app.yml` using the same single-job, samuelmeuli-driven, tag-published pattern as Linux and Windows. Fixes the `EEXIST` packaging failure that has been preventing any mac build (CI or local) from succeeding. Also bumps the app version `26.6.3 → 26.6.8` (YY.M.D, today) so the next dispatch produces a fresh, distinct release.

## What changed

### `package.json` — drop duplicate `fileAssociations` icons

```diff
       {
         "ext": "har",
-        "icon": "assets/icon.icns"
       },
       {
         "ext": "rqly",
-        "icon": "assets/icon.icns"
       }
```

Both `.har` and `.rqly` entries pointed at the **same** `assets/icon.icns`. electron-builder's macOS packaging stages each `fileAssociation` icon into the `.app`'s `Contents/Resources/` via `fs.linkSync` — second link to the same target → `EEXIST: file already exists`. Verified on `requestly-desktop-dev` (probe run [#27125251380](https://github.com/requestly/requestly-desktop-dev/actions/runs/27125251380/job/80052081565)):

```
⨯ EEXIST: file already exists, link '.../assets/icon.icns'
  -> '.../release/build/mac/Electron.app/Contents/Resources/icon.icns'
failedTask=build
```

No effect on Windows or Linux builds (`fileAssociations` icons are macOS-only).

### `.github/workflows/release_desktop_app.yml` — add `macos-latest`

- Adds `macos-latest` as a third `build_type` choice (was commented out).
- Replaces the commented-out `APPLE_ID` / `APPLE_ID_PASS` env block (referenced lowercase secrets that don't exist) with `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` from secrets. These feed electron-builder@24's built-in notarytool flow; `teamId` is hardcoded in `package.json` (public info embedded in any signed binary anyway).
- Refreshes the header comment so the per-platform signing model (macOS Apple Developer ID / Windows GCP KMS / Linux unsigned) is documented accurately.

**Mac cert secret rename (separate commit `abb19c7`):** the samuelmeuli `mac_certs` / `mac_certs_password` inputs now read from `secrets.bstack_mac_certs` / `secrets.bstack_mac_certs_password` instead of the legacy `MAC_CERTS` / `MAC_CERTS_PASSWORD` names. The new BrowserStack-prefixed names line up with how the cert is being provisioned going forward.

**Same shape as Linux/Windows on purpose:**
- Single job, `runs-on: ${{ inputs.build_type }}` — mac just gets a third option.
- `samuelmeuli/action-electron-builder@v1.6.0` with `release: true`, `github_token: secrets.publish_token` — same tag-driven GH Releases upload path.
- GCP KMS steps remain Windows-only (`if: build_type == 'windows-latest'`); the `win.sign` hook self-skips when `USE_KMS_SIGNING` is empty.

### Version bump `26.6.3 → 26.6.8`

YY.M.D, today's date. Touched 4 manifests so every consumer (electron-builder, GH Release tag, auto-update manifest) sees the same string:

- `package.json`
- `release/app/package.json`
- `package-lock.json`
- `release/app/package-lock.json`

## Repo secrets — required state

All required secrets now exist on `requestly/http-interceptor-desktop-app` (added earlier today). For the record:

| Secret | Purpose |
|---|---|
| `BSTACK_MAC_CERTS` | Base64 P12 (Apple Developer ID cert + private key) |
| `BSTACK_MAC_CERTS_PASSWORD` | P12 password |
| `APPLE_ID` | Apple ID of the signing account, for notarization |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password for that Apple ID |
| `PUBLISH_TOKEN` | PAT used by samuelmeuli to publish to GH Releases (already existed) |
| `SENTRY_AUTH_TOKEN` | Sourcemap upload (already existed) |
| `WINDOWS_CODESIGN_CERT_BASE64` | Public Authenticode leaf cert (Windows, already existed) |

## Test plan

- [ ] Tag a commit (e.g. `v26.6.8`) on `master` after merge
- [ ] Dispatch `release_desktop_app.yml` with `build_type: macos-latest`
- [ ] Job completes; `.dmg` + `.zip` + `latest-mac.yml` land on the GH Release matching the tag
- [ ] `codesign -dv --verbose=4 Requestly.app` → `Authority=Developer ID Application: BrowserStack Inc (YQ5FZQ855D)`, notarized
- [ ] Re-dispatch `windows-latest` and `ubuntu-latest` once each to confirm no regression on the existing paths

## Known caveats (deliberately not in this PR)

`mac.identity: "Browserstack Inc (YQ5FZQ855D)"` is still hardcoded in `package.json`. CI will be fine as long as the cert inside `BSTACK_MAC_CERTS` has that exact CN. Local mac builds on developer machines will still hit "identity not found" unless their keychain happens to have that identity. Removing this line entirely (which is what `requestly-desktop-dev` does) makes the build robust against re-issued certs and unblocks local packaging too — happy to do that as a follow-up if it's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
