### PR TITLE
RQ-3113: origin allowlist for change-webapp-url (+ navigation guard)

### DIFF
--- a/src/main/events.js
+++ b/src/main/events.js
@@ -22,7 +22,7 @@ import { createOrUpdateAxiosInstance } from "./actions/getProxiedAxios";
 // todo: refactor main.ts to only export core entities like webappWindow
 // and then build these utilites elsewhere
 // eslint-disable-next-line import/no-cycle
-import createTrayMenu, { loadWebAppUrl } from "./main";
+import createTrayMenu, { loadWebAppUrl, isAllowedWebAppUrl } from "./main";
 import {
   fetchAndSaveSecrets,
   getSecretProviderConfig,
@@ -225,10 +225,15 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
 
   ipcMain.handle("change-webapp-url", async (event, payload) => {
     try {
-      const { url } = payload;
-      if (!url || typeof url !== "string") {
-        new URL(url);
+      const url = payload?.url;
+      // RQ-3113: validate type, then enforce the origin allowlist. The previous
+      // guard was inverted (it only ran new URL(url) when url was falsy), so any
+      // real string reached loadWebAppUrl unchecked.
+      if (typeof url !== "string") {
         return { success: false, error: "Invalid URL provided" };
+      }
+      if (!isAllowedWebAppUrl(url)) {
+        return { success: false, error: "URL not allowed" };
       }
       await loadWebAppUrl(url);
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -210,6 +210,47 @@ const getWebAppURL = (): string => {
     : "https://app.requestly.io";
 };
 
+// RQ-3113: webAppWindow holds the privileged preload bridge, so it must only
+// ever load origins we own. Used both by the change-webapp-url IPC handler and
+// as a navigation guard. Matches the full hostname (not substrings) so
+// look-alikes like requestly.io.evil.com / xrequestly-dev.web.app are rejected.
+// Firebase preview channels deploy to the requestly-dev hosting site, e.g.
+// https://requestly-dev--<branch>-<hash>.web.app
+const FIREBASE_PREVIEW_HOST = /^requestly-dev--[a-z0-9-]+\.web\.app$/;
+
+export const isAllowedWebAppUrl = (rawUrl: string): boolean => {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+
+  const host = parsed.hostname;
+
+  // Local dev server — only in development builds, never in a packaged app.
+  if (host === "localhost" || host === "127.0.0.1") {
+    return isDevelopment;
+  }
+
+  // Everything else must be served over HTTPS.
+  if (parsed.protocol !== "https:") {
+    return false;
+  }
+
+  // Any requestly.io origin (app, beta, staging, EAP).
+  if (host === "requestly.io" || host.endsWith(".requestly.io")) {
+    return true;
+  }
+
+  // Beta/preview Firebase channels.
+  if (FIREBASE_PREVIEW_HOST.test(host)) {
+    return true;
+  }
+
+  return false;
+};
+
 let closingAccepted = false;
 const createWindow = async () => {
   if (isDevelopment) {
@@ -351,6 +392,24 @@ const createWindow = async () => {
     shell.openExternal(details.url);
     return { action: "deny" };
   });
+
+  // RQ-3113: defense-in-depth. The IPC handler is the front door; this blocks
+  // any other way the privileged window could be navigated off our origins
+  // (in-page navigation, JS redirects, HTTP 3xx). SPA client-side routing uses
+  // the History API and does not trigger these events, so this is transparent
+  // to normal use; external links already open in the browser via the handler
+  // above and the requestly:// deep-link flow.
+  const blockDisallowedNavigation = (
+    event: Electron.Event,
+    targetUrl: string
+  ) => {
+    if (!isAllowedWebAppUrl(targetUrl)) {
+      console.warn("Blocked navigation to disallowed URL:", targetUrl);
+      event.preventDefault();
+    }
+  };
+  webAppWindow.webContents.on("will-navigate", blockDisallowedNavigation);
+  webAppWindow.webContents.on("will-redirect", blockDisallowedNavigation);
 };
 
 let onWebAppReadyHandlers: (() => void)[] = [];
@@ -504,11 +563,17 @@ export const loadWebAppUrl = async (newURL: string) => {
   if (!webAppWindow || webAppWindow.isDestroyed()) {
     throw new Error("Web app window is not available");
   }
-  
+
+  // RQ-3113: never trust the caller — re-check the origin before navigating the
+  // privileged window, and never persist a disallowed URL into customWebAppURL.
+  if (!isAllowedWebAppUrl(newURL)) {
+    throw new Error("URL not allowed");
+  }
+
   await webAppWindow.loadURL(newURL, {
     extraHeaders: "pragma: no-cache\n",
   });
-  
+
   customWebAppURL = newURL;
   
   if (!webAppWindow.isVisible()) {


### PR DESCRIPTION
Security fix for **RQ-3113** (Critical) — arbitrary URL into the privileged window.

## Problem
`change-webapp-url` navigated `webAppWindow` (which holds the privileged `RQ.DESKTOP.SERVICES` preload bridge) to any renderer-supplied URL — its guard was inverted (`new URL()` only ran in the falsy branch). A renderer foothold could pivot the privileged window to an attacker origin (persisted via `customWebAppURL`) and inherit full IPC.

## Fix
`isAllowedWebAppUrl()` — full-hostname allowlist: `*.requestly.io` (https), `requestly-dev--*.web.app` (Firebase preview channels), `localhost`/`127.0.0.1` in dev only. Fix the inverted guard; re-validate in `loadWebAppUrl` (no poisoned `customWebAppURL`); add `will-navigate`/`will-redirect` guards as defense-in-depth.

## Verified
19/19 cases: attack vectors (`evil.example`, `beta.evil.com`, `anyone.web.app`, suffix look-alikes, `file:`/`javascript:`, localhost-in-prod) rejected; legit origins allowed. Desktop auth is `requestly://` deep-link based, so the nav guard won't break login. Draft — pending review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation for app navigation to restrict access to approved origins only, including localhost (development only), HTTPS connections, and specific authorized domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->