### PR TITLE
RQ-3115: ship Electron 27 instead of EOL 23 (interim)

### DIFF
--- a/electron-builder-setapp.json
+++ b/electron-builder-setapp.json
@@ -1,7 +1,7 @@
 {
   "productName": "Requestly",
   "appId": "io.requestly.beta-setapp",
-  "electronVersion": "23.0.0",
+  "electronVersion": "27.3.11",
   "asar": true,
   "asarUnpack": "**\\*.{node,dll}",
   "files": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "build": {
     "productName": "Requestly",
     "appId": "io.requestly.beta",
-    "electronVersion": "23.0.0",
+    "electronVersion": "27.3.11",
     "asar": true,
     "asarUnpack": "**\\*.{node,dll}",
     "files": [


### PR DESCRIPTION
Security fix for **RQ-3115** (Critical) — EOL Electron shipped to users.

## Problem
Both electron-builder configs hardcoded `electronVersion: "23.0.0"`, so the packaged app shipped **Electron 23** (Chromium ~110, EOL) even though dev/devDep run **27.3.11** — users ran an older, untested runtime than developers.

## Fix
`electronVersion` `23.0.0`→`27.3.11` in `package.json` (build block) + `electron-builder-setapp.json`. Chromium ~110→~118; ships what dev already tests on.

## Verified
`npm run build` (prod) + `electron-builder --dir` pass; packaged `Requestly.app` embeds Electron Framework `CFBundleVersion = 27.3.11`.

## ⚠️ Caveats
- **Not validated here**: signing/notarization, Setapp universal build, packaged-app runtime — verify in the signed pipeline. Non-fatal `registry-js` arm64 prebuild 404 during `--dir`.
- **Interim only** — 27 is also EOL. Full upgrade to a supported major (native rebuilds incl. isolated-vm, `@electron/remote` migration, notarization) is a separate planned effort.

Draft — pending review.