### PR TITLE
Revert RQ-3110 (PR #348) — backed out, re-raised via #NEW

### DIFF
--- a/src/lib/storage/action-processors/accessed-files.ts
+++ b/src/lib/storage/action-processors/accessed-files.ts
@@ -35,23 +35,6 @@ export default class AccessedFilesProcessor extends BaseActionProcessor {
       );
     }
 
-    // RQ-3110: flat list of every tracked accessed file across all categories.
-    // Used to confine get-file-contents to files the user actually opened.
-    if (type === ACCESSED_FILES.GET_ALL) {
-      const categories: AccessedFileCategoryTag[] = ["web-session", "har", "unknown"];
-      const allFiles: AccessedFile[] = [];
-      categories.forEach((cat) => {
-        const records = this.store.get(cat) as Record<
-          AccessedFile["filePath"],
-          AccessedFile
-        >;
-        if (records) {
-          allFiles.push(...Object.values(records));
-        }
-      });
-      return allFiles;
-    }
-
     if (type === ACCESSED_FILES.ADD) {
       const file = payload?.data as AccessedFile;
       category = file.category;

--- a/src/main/events.js
+++ b/src/main/events.js
@@ -90,32 +90,6 @@ function removeFileFromAccessRecords(filePath) {
   });
 }
 
-// RQ-3110: the renderer (nodeIntegration: false) must not be able to read
-// arbitrary files via get-file-contents. Confine reads to files the user
-// actually opened through the app — the recently-accessed records. Both the
-// requested path and the stored paths are resolved with realpathSync so
-// symlinks and ".." traversal can't escape, and a look-alike path can't match.
-function isAccessedFilePathAllowed(requestedPath) {
-  if (typeof requestedPath !== "string" || !requestedPath) {
-    return false;
-  }
-  let resolved;
-  try {
-    resolved = fs.realpathSync(requestedPath);
-  } catch (e) {
-    return false;
-  }
-  const accessedFiles =
-    storageService.processAction({ type: "ACCESSED_FILES:GET_ALL" }) || [];
-  return accessedFiles.some((record) => {
-    try {
-      return fs.realpathSync(record.filePath) === resolved;
-    } catch (e) {
-      return false;
-    }
-  });
-}
-
 // These events do not require the browser window
 export const registerMainProcessEvents = () => {
   ipcMain.on("background-process-started", () => {
@@ -312,15 +286,8 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
   });
 
   ipcMain.handle("get-file-contents", async (event, payload) => {
-    const filePath = payload?.filePath;
-    // RQ-3110: only read files the user opened through the app. Disallowed paths
-    // return the same "not found" the caller already handles — no read, and no
-    // existence oracle for arbitrary paths.
-    if (!isAccessedFilePathAllowed(filePath)) {
-      return "err:NOT FOUND";
-    }
     try {
-      const fileContents = fs.readFileSync(filePath, "utf-8");
+      const fileContents = fs.readFileSync(payload.filePath, "utf-8");
       if (!fileContents) {
         throw new Error("File is empty");
       }
@@ -328,7 +295,7 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
     } catch (e) {
       console.log(e);
       // delete file from recently accessed
-      removeFileFromAccessRecords(filePath);
+      removeFileFromAccessRecords(payload.filePath);
       return "err:NOT FOUND";
     }
   });
@@ -433,11 +400,6 @@ export const registerMainProcessCommonEvents = () => {
         for (const filePath of filePaths) {
           const { size } = fs.statSync(filePath);
           const name = path.basename(filePath);
-          // RQ-3110: a file chosen here is a user gesture, so record it as
-          // accessed — get-file-contents is confined to accessed files, and
-          // some flows (e.g. the API client collection-runner data file) read
-          // the picked path back through that IPC.
-          trackRecentlyAccessedFile(filePath);
           files.push({ path: filePath, name, size });
         }
         return { canceled, files };


### PR DESCRIPTION
Reverts the RQ-3110 file-read confinement (`df494b2` + `7015c9c`) that was merged to master via #348 prematurely.

**Why:** #348 was merged before review/release coordination. Backing it out so RQ-3110 lands through a proper reviewed PR. The actual fix is re-raised in a fresh draft PR (stacked on this branch) — merge **this** revert first, then that one retargets to master.

No RQ-3110 behavior remains on master after this merge (`get-file-contents` returns to its prior behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal file access handling by removing allowlist validation and recently accessed file tracking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->