### PR TITLE
RQ-3110: confine get-file-contents to opened files (re-raised)

### DIFF
--- a/src/lib/storage/action-processors/accessed-files.ts
+++ b/src/lib/storage/action-processors/accessed-files.ts
@@ -35,6 +35,23 @@ export default class AccessedFilesProcessor extends BaseActionProcessor {
       );
     }
 
+    // RQ-3110: flat list of every tracked accessed file across all categories.
+    // Used to confine get-file-contents to files the user actually opened.
+    if (type === ACCESSED_FILES.GET_ALL) {
+      const categories: AccessedFileCategoryTag[] = ["web-session", "har", "unknown"];
+      const allFiles: AccessedFile[] = [];
+      categories.forEach((cat) => {
+        const records = this.store.get(cat) as Record<
+          AccessedFile["filePath"],
+          AccessedFile
+        >;
+        if (records) {
+          allFiles.push(...Object.values(records));
+        }
+      });
+      return allFiles;
+    }
+
     if (type === ACCESSED_FILES.ADD) {
       const file = payload?.data as AccessedFile;
       category = file.category;

--- a/src/main/events.js
+++ b/src/main/events.js
@@ -433,6 +433,11 @@ export const registerMainProcessCommonEvents = () => {
         for (const filePath of filePaths) {
           const { size } = fs.statSync(filePath);
           const name = path.basename(filePath);
+          // RQ-3110: a file chosen here is a user gesture, so record it as
+          // accessed — get-file-contents is confined to accessed files, and
+          // some flows (e.g. the API client collection-runner data file) read
+          // the picked path back through that IPC.
+          trackRecentlyAccessedFile(filePath);
           files.push({ path: filePath, name, size });
         }
         return { canceled, files };

--- a/src/main/events.js
+++ b/src/main/events.js
@@ -90,6 +90,32 @@ function removeFileFromAccessRecords(filePath) {
   });
 }
 
+// RQ-3110: the renderer (nodeIntegration: false) must not be able to read
+// arbitrary files via get-file-contents. Confine reads to files the user
+// actually opened through the app — the recently-accessed records. Both the
+// requested path and the stored paths are resolved with realpathSync so
+// symlinks and ".." traversal can't escape, and a look-alike path can't match.
+function isAccessedFilePathAllowed(requestedPath) {
+  if (typeof requestedPath !== "string" || !requestedPath) {
+    return false;
+  }
+  let resolved;
+  try {
+    resolved = fs.realpathSync(requestedPath);
+  } catch (e) {
+    return false;
+  }
+  const accessedFiles =
+    storageService.processAction({ type: "ACCESSED_FILES:GET_ALL" }) || [];
+  return accessedFiles.some((record) => {
+    try {
+      return fs.realpathSync(record.filePath) === resolved;
+    } catch (e) {
+      return false;
+    }
+  });
+}
+
 // These events do not require the browser window
 export const registerMainProcessEvents = () => {
   ipcMain.on("background-process-started", () => {
@@ -286,8 +312,15 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
   });
 
   ipcMain.handle("get-file-contents", async (event, payload) => {
+    const filePath = payload?.filePath;
+    // RQ-3110: only read files the user opened through the app. Disallowed paths
+    // return the same "not found" the caller already handles — no read, and no
+    // existence oracle for arbitrary paths.
+    if (!isAccessedFilePathAllowed(filePath)) {
+      return "err:NOT FOUND";
+    }
     try {
-      const fileContents = fs.readFileSync(payload.filePath, "utf-8");
+      const fileContents = fs.readFileSync(filePath, "utf-8");
       if (!fileContents) {
         throw new Error("File is empty");
       }
@@ -295,7 +328,7 @@ export const registerMainProcessEventsForWebAppWindow = (webAppWindow) => {
     } catch (e) {
       console.log(e);
       // delete file from recently accessed
-      removeFileFromAccessRecords(payload.filePath);
+      removeFileFromAccessRecords(filePath);
       return "err:NOT FOUND";
     }
   });


### PR DESCRIPTION
Re-raise of **RQ-3110** after reverting the premature merge of #348. Same change (cherry-picked `df494b2` + `7015c9c`), now going through review properly.

## What
- Confine `get-file-contents` to files the user opened through the app (the recently-accessed records); `realpathSync` match so symlinks/`..` can't escape.
- Implement `ACCESSED_FILES:GET_ALL` (was declared, unhandled).
- Record `open-file-dialog` picks as accessed too — fixes the API-client **collection-runner** data-file regression (CSV/JSON picked there is read back via `get-file-contents`).

## Verified
9/9 confinement logic cases; collection-runner data-file read works (pick → tracked → readable), survives restart (recents store is persisted).

## Notes
- Base is `revert/RQ-3110-pr-348` so the diff shows cleanly now; **after the revert PR merges to master, GitHub auto-retargets this PR's base to `master`.**
- Pre-existing `removeFileFromAccessRecords` `delete undefined[...]` crash is still present (separate small hardening; flagged).
- Migration edge: a data file picked on a pre-3110 build needs a one-time re-pick.

Draft — pending review.