### PR TITLE
chore(release): proxy 1.5.0 + app version 26.6.22 (RQ-2425)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "26.6.8",
+  "version": "26.6.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "26.6.8",
+      "version": "26.6.22",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@devicefarmer/adbkit": "^3.2.6",
         "@electron/remote": "^2.1.2",
         "@requestly/requestly-core": "1.1.1",
-        "@requestly/requestly-proxy": "1.4.0",
+        "@requestly/requestly-proxy": "1.5.0",
         "@sentry/browser": "^8.34.0",
         "@sentry/electron": "^5.6.0",
         "@sinclair/typebox": "^0.34.25",
@@ -3407,9 +3407,9 @@
       "integrity": "sha512-/1Kj71UGT5ojK2y+UWxpbX3WLNt+mLlXi6Jd7gK48MeEXrZqlrkWYIPaGIHxhbg2UdADVawfDeOv69ns6cmuMQ=="
     },
     "node_modules/@requestly/requestly-proxy": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.4.0.tgz",
-      "integrity": "sha512-9ZDNe6q6z117ndPOMDf5o5uZadzXU61sbJW77CBjmGQ7e+UozgxFToA8UcB85YEP/thZjpEugboK5E3FPX61dQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.5.0.tgz",
+      "integrity": "sha512-0ZvtnL0M7NS93NpdU3GgYI9TUzSaVinQYhIJ+rP7NUAxJr7IVle6Upjgfeim3Lgoh4xXWSAD/ilrYwIqTYRHFQ==",
       "license": "ISC",
       "dependencies": {
         "@requestly/requestly-core": "1.1.1",
@@ -21506,9 +21506,9 @@
       "integrity": "sha512-/1Kj71UGT5ojK2y+UWxpbX3WLNt+mLlXi6Jd7gK48MeEXrZqlrkWYIPaGIHxhbg2UdADVawfDeOv69ns6cmuMQ=="
     },
     "@requestly/requestly-proxy": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.4.0.tgz",
-      "integrity": "sha512-9ZDNe6q6z117ndPOMDf5o5uZadzXU61sbJW77CBjmGQ7e+UozgxFToA8UcB85YEP/thZjpEugboK5E3FPX61dQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.5.0.tgz",
+      "integrity": "sha512-0ZvtnL0M7NS93NpdU3GgYI9TUzSaVinQYhIJ+rP7NUAxJr7IVle6Upjgfeim3Lgoh4xXWSAD/ilrYwIqTYRHFQ==",
       "requires": {
         "@requestly/requestly-core": "1.1.1",
         "@sentry/browser": "^8.33.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.6.8",
+  "version": "26.6.22",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "@devicefarmer/adbkit": "^3.2.6",
     "@electron/remote": "^2.1.2",
     "@requestly/requestly-core": "1.1.1",
-    "@requestly/requestly-proxy": "1.4.0",
+    "@requestly/requestly-proxy": "1.5.0",
     "@sentry/browser": "^8.34.0",
     "@sentry/electron": "^5.6.0",
     "@sinclair/typebox": "^0.34.25",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "26.6.8",
+  "version": "26.6.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "26.6.8",
+      "version": "26.6.22",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.6.8",
+  "version": "26.6.22",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
Two release-prep changes for **RQ-2425** (Phase 2 of the proxy→desktop→web rollout):

### 1. Bump bundled proxy `1.4.0 → 1.5.0`
Picks up the RQ-2425 engine: verify upstream TLS by default (`rejectUnauthorized = !allowInsecureCerts`), the `setAllowInsecureCerts` live setter (toggle applies without a proxy restart), and clear SSL cert-error pages. Validated: real install downloaded + integrity-verified 1.5.0, contains the RQ-2425 code, **no** `isolated-vm` (1.5.0 = RQ-2425 only, not the sandbox). `package.json` + lockfile exact-pinned `1.5.0`.

### 2. Bump app version `26.6.8 → 26.6.22`
Required so the web **"Allow insecure SSL"** toggle (gated to desktop ≥ `26.6.22`) appears once shipped. Bumped both `package.json` (dev version via preload) and `release/app/package.json` (packaged `app.getVersion()`), plus both lockfiles → `RQ.DESKTOP.VERSION` reads `26.6.22` in dev and packaged builds.

> ⚠️ Cooldown note: proxy 1.5.0 was published today; if release CI enforces the org's 5-day new-package cooldown the build may be blocked until it expires (or override). (User has removed the cooldown locally.)

Does **not** include the Electron 27 upgrade (RQ-3115) — that's a separate, not-yet-ready PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **26.6.22**.
  * Updated the `@requestly/requestly-proxy` dependency to the latest version (**1.5.0**).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->