### PR TITLE
ci: pin Windows release runner to windows-2022

### DIFF
--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -42,7 +42,9 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
 
-    if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
+    # TEMP: branch gate disabled to test the workflow from this PR branch.
+    # RESTORE before merge:
+    # if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
     runs-on: ${{ github.event.inputs.build_type }}
 
     steps:

--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -25,9 +25,9 @@ on:
         type: choice
         options:
           - ubuntu-latest
-          - windows-latest
+          - windows-2022
           - macos-latest
-        default: windows-latest
+        default: windows-2022
 
 jobs:
   release:
@@ -64,7 +64,7 @@ jobs:
       # Replaces the legacy `Install Distutils` step. node-gyp@9.3.1 (the
       # legacy app's pinned version) still imports distutils.version, which
       # Python 3.12+ removed (PEP 632). Pinning Python to 3.11 brings
-      # distutils back as stdlib for both windows-latest and ubuntu-latest
+      # distutils back as stdlib for both windows-2022 and ubuntu-latest
       # runners.
       - name: Set up Python 3.11 for node-gyp
         uses: actions/setup-python@v5
@@ -75,18 +75,18 @@ jobs:
         run: bash ./install.sh
 
       # ─── Windows: GCP KMS signing setup (replaces windows_certs P12) ────
-      # Runs only on windows-latest. The MSI + config drop is required so
+      # Runs only on windows-2022. The MSI + config drop is required so
       # signtool can use the "Google Cloud KMS Provider" CSP from the
       # win.sign hook later in the build step.
       - name: Auth to Google Cloud (KMS)
-        if: ${{ github.event.inputs.build_type == 'windows-latest' }}
+        if: ${{ github.event.inputs.build_type == 'windows-2022' }}
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
 
       - name: Install + configure KMS CNG provider
-        if: ${{ github.event.inputs.build_type == 'windows-latest' }}
+        if: ${{ github.event.inputs.build_type == 'windows-2022' }}
         shell: pwsh
         env:
           GCP_PROJECT_ID: ${{ vars.WIN_SIGN_KMS_PROJECT }}
@@ -135,7 +135,7 @@ jobs:
           # ─── Windows GCP KMS signing (consumed by scripts/windows-kms-sign.js) ──
           # On non-Windows builds these resolve to empty / are unused; the
           # sign script self-skips when USE_KMS_SIGNING is not 'true'.
-          USE_KMS_SIGNING: ${{ github.event.inputs.build_type == 'windows-latest' && 'true' || '' }}
+          USE_KMS_SIGNING: ${{ github.event.inputs.build_type == 'windows-2022' && 'true' || '' }}
           WIN_SIGN_CERT_BASE64: ${{ secrets.WINDOWS_CODESIGN_CERT_BASE64 }}
           GCP_PROJECT_ID: ${{ vars.WIN_SIGN_KMS_PROJECT }}
           GCP_KMS_LOCATION: ${{ vars.WIN_SIGN_KMS_LOCATION }}

--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -42,9 +42,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
 
-    # TEMP: branch gate disabled to test the workflow from this PR branch.
-    # RESTORE before merge:
-    # if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
+    if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
     runs-on: ${{ github.event.inputs.build_type }}
 
     steps:


### PR DESCRIPTION
## Why

The **Release Desktop App** workflow has been failing during *Install desktop app dependencies* (e.g. [run 27961047810](https://github.com/requestly/http-interceptor-desktop-app/actions/runs/27961047810)). The `registry-js` native module fails to compile because node-gyp can't find a usable Visual Studio:

```
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```

`windows-latest` now provisions the **VS 2026 (v18)** toolchain, which the bundled **node-gyp@9.3.1** (from Node 20.9.0) cannot detect — it parses the version as `undefined` and bails. Not a code change on our side; the runner image moved.

## What

Pin the Windows runner to **windows-2022** (VS 2022 / v17), which node-gyp understands. Replaced `windows-latest` across:

- the `build_type` dropdown option and its default
- the two Windows-only KMS signing step gates (`Auth to Google Cloud`, `Install + configure KMS CNG provider`)
- the `USE_KMS_SIGNING` env expression

All changed together so `runs-on` and the `== 'windows-2022'` gates stay consistent — otherwise the codesigning steps would silently stop matching and produce an unsigned build.

## Note

`windows-2022` is being deprecated by GitHub over time, so this is a stable pin, not a permanent fix. The durable fix is upgrading node-gyp/Node to recognize VS 2026 — worth a follow-up.

## Testing

Re-run the release workflow and select **windows-2022** (now the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Windows desktop application release workflow to standardize builds on **Windows 2022**. The manual build option now defaults to Windows 2022, and Windows-only Google Cloud KMS signing steps are now applied only to Windows 2022 builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->