### PR TITLE
ci: bump release workflow Node 20.9.0 → 22.12.0 (fix ERR_REQUIRE_ESM)

### DIFF
--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -59,7 +59,11 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 20.9.0
+          # Electron 42 toolchain: electron-builder 26.x's app-builder-lib
+          # require()s ESM-only @noble/hashes@2.x. require(ESM) is unflagged only
+          # on Node >=20.19 / >=22.12, so the old 20.9.0 pin fails with
+          # ERR_REQUIRE_ESM. Match devEngines (>=22.12.0).
+          node-version: 22.12.0
 
       # Replaces the legacy `Install Distutils` step. node-gyp@9.3.1 (the
       # legacy app's pinned version) still imports distutils.version, which

--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -42,9 +42,7 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
 
-    # TEMP — RESTORE BEFORE MERGING #359. Guard disabled so the release build can
-    # be dispatched from this branch to validate the Node 22.12 bump.
-    # if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
+    if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
     runs-on: ${{ github.event.inputs.build_type }}
 
     steps:
@@ -61,10 +59,6 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          # Electron 42 toolchain: electron-builder 26.x's app-builder-lib
-          # require()s ESM-only @noble/hashes@2.x. require(ESM) is unflagged only
-          # on Node >=20.19 / >=22.12, so the old 20.9.0 pin fails with
-          # ERR_REQUIRE_ESM. Match devEngines (>=22.12.0).
           node-version: 22.12.0
 
       # Replaces the legacy `Install Distutils` step. node-gyp@9.3.1 (the

--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -42,7 +42,9 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
 
-    if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
+    # TEMP — RESTORE BEFORE MERGING #359. Guard disabled so the release build can
+    # be dispatched from this branch to validate the Node 22.12 bump.
+    # if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
     runs-on: ${{ github.event.inputs.build_type }}
 
     steps:


### PR DESCRIPTION
## Problem
All three OS release builds (Linux/macOS/Windows) fail at `electron-builder install-app-deps`:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module @noble/hashes/blake2.js
  from app-builder-lib/.../blockmap/blockmap.js not supported
```

## Root cause
The Electron 42 upgrade bumped **electron-builder → 26.15.3**, whose `app-builder-lib` `require()`s **ESM-only `@noble/hashes@^2.2.0`**. Node's unflagged `require(ESM)` support landed in **20.19 / 22.12** — but the release workflow was still pinned at **`node-version: 20.9.0`**, which predates it → `ERR_REQUIRE_ESM`.

The same upgrade already bumped `devEngines` to `>=22.12.0`; this workflow just wasn't updated to match. (The OS build only runs on `master`, so the PR-level CI on the Electron-42 PR never caught it.)

## Fix
`release_desktop_app.yml`: `node-version: 20.9.0` → `22.12.0` (matches `devEngines`).

## Verification
- `require("@noble/hashes/blake2.js")` (exact `2.2.0`, ESM-only) **fails on Node 20.9-era, works on Node 20.20.0 / 22.22.1**.
- A local `electron-builder` package build succeeds on **Node 22.22.1**.
- Not related to any proxy/app dependency change — purely the CI Node pin.

After merge: re-dispatch **Release Desktop App** for ubuntu-latest / windows-latest / macos-latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app release workflow to use a newer Node.js version for builds.
  * Added guidance comments to clarify the release dispatch check and future rollback option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->