### PR TITLE
ci(macos): set APPLE_TEAM_ID for electron-builder notarization

### DIFF
--- a/.github/workflows/release_desktop_app.yml
+++ b/.github/workflows/release_desktop_app.yml
@@ -41,6 +41,7 @@ jobs:
       # the action then skips notarization cleanly.
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
 
     if: github.ref == 'refs/heads/master'|| github.ref == 'refs/heads/production'
     runs-on: ${{ github.event.inputs.build_type }}


### PR DESCRIPTION
## Problem
The **macOS** release build signs successfully but fails at the very end:

```
✗ APPLE_TEAM_ID env var needs to be set
Error: Command failed: npx --no-install electron-builder --mac --publish always
```

`electron-builder` 26's notarytool flow (from the Electron 42 upgrade) requires **`APPLE_TEAM_ID`** as an env var — it's no longer inferred from `package.json`'s `mac.identity`. The workflow set `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` but not the team id.

## Fix
Add `APPLE_TEAM_ID` to the release-job env, sourced from a repo **Variable** (it's public — same id as `mac.identity` "Browserstack Inc (YQ5FZQ855D)" and visible in build logs, so a Variable rather than a Secret).

- Repo Variable `APPLE_TEAM_ID = YQ5FZQ855D` is already created (Settings → Variables).
- Net change: one env line `APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}`.

## Notes
- Last of the Electron-42-upgrade release-build gaps (after #359 Node 22.12 and #360 registry-js 1.16.1).
- Needs a **Release Desktop App → macos-latest** dispatch to confirm notarization completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the macOS desktop app release process to include the required Apple team identifier for notarization.
  * This helps ensure desktop app builds continue to be correctly signed and distributed successfully on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->