### PR TITLE
chore(release): proxy 1.5.2 + app version 26.6.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "requestly",
-  "version": "26.6.26",
+  "version": "26.6.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "requestly",
-      "version": "26.6.26",
+      "version": "26.6.29",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -14,7 +14,7 @@
         "@devicefarmer/adbkit": "^3.2.6",
         "@electron/remote": "^2.1.2",
         "@requestly/requestly-core": "1.1.1",
-        "@requestly/requestly-proxy": "1.5.1",
+        "@requestly/requestly-proxy": "1.5.2",
         "@sentry/browser": "^8.34.0",
         "@sentry/electron": "^5.6.0",
         "@sinclair/typebox": "^0.34.25",
@@ -2575,21 +2575,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/@jitl/quickjs-ffi-types": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.32.0.tgz",
-      "integrity": "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==",
-      "license": "MIT"
-    },
-    "node_modules/@jitl/quickjs-singlefile-cjs-release-sync": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-singlefile-cjs-release-sync/-/quickjs-singlefile-cjs-release-sync-0.32.0.tgz",
-      "integrity": "sha512-NjUUcw26PoeJHND6nmflAH8nIvAJvxJ2qkSPi95wfiBqPim80GtcdWommroiWb8hh1/7fVettEwodAsGt2Mrsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jitl/quickjs-ffi-types": "0.32.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "dev": true,
@@ -3512,12 +3497,11 @@
       "integrity": "sha512-/1Kj71UGT5ojK2y+UWxpbX3WLNt+mLlXi6Jd7gK48MeEXrZqlrkWYIPaGIHxhbg2UdADVawfDeOv69ns6cmuMQ=="
     },
     "node_modules/@requestly/requestly-proxy": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.5.1.tgz",
-      "integrity": "sha512-DFx3smcGrqnqnAjcsX2YHTq3MSOgWiEmUANlwmt8zwynCMFlSH+MzXO5BvUEej+H2c7d3HQIc3bO26wUdVlhcQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.5.2.tgz",
+      "integrity": "sha512-dhYbLQYTXUO0rDUbmPp09MPLGPxODeH23SbBwiYTBDqMa0I2u+ySs5rs9P+5SSvcRwdwYqlJ8laWa9qBPbmp/A==",
       "license": "ISC",
       "dependencies": {
-        "@jitl/quickjs-singlefile-cjs-release-sync": "^0.32.0",
         "@requestly/requestly-core": "1.1.1",
         "@sentry/browser": "^8.33.1",
         "async": "^3.2.5",
@@ -3530,7 +3514,6 @@
         "mime-types": "^2.1.35",
         "mkdirp": "^0.5.5",
         "node-forge": "^1.3.0",
-        "quickjs-emscripten-core": "^0.32.0",
         "semaphore": "^1.1.0",
         "ua-parser-js": "^1.0.37",
         "url": "^0.11.3",
@@ -15689,15 +15672,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/quickjs-emscripten-core": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/quickjs-emscripten-core/-/quickjs-emscripten-core-0.32.0.tgz",
-      "integrity": "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jitl/quickjs-ffi-types": "0.32.0"
-      }
-    },
     "node_modules/raf": {
       "version": "3.4.1",
       "dev": true,
@@ -20832,19 +20806,6 @@
         "chalk": "^4.0.0"
       }
     },
-    "@jitl/quickjs-ffi-types": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.32.0.tgz",
-      "integrity": "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="
-    },
-    "@jitl/quickjs-singlefile-cjs-release-sync": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-singlefile-cjs-release-sync/-/quickjs-singlefile-cjs-release-sync-0.32.0.tgz",
-      "integrity": "sha512-NjUUcw26PoeJHND6nmflAH8nIvAJvxJ2qkSPi95wfiBqPim80GtcdWommroiWb8hh1/7fVettEwodAsGt2Mrsg==",
-      "requires": {
-        "@jitl/quickjs-ffi-types": "0.32.0"
-      }
-    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "dev": true,
@@ -21456,11 +21417,10 @@
       "integrity": "sha512-/1Kj71UGT5ojK2y+UWxpbX3WLNt+mLlXi6Jd7gK48MeEXrZqlrkWYIPaGIHxhbg2UdADVawfDeOv69ns6cmuMQ=="
     },
     "@requestly/requestly-proxy": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.5.1.tgz",
-      "integrity": "sha512-DFx3smcGrqnqnAjcsX2YHTq3MSOgWiEmUANlwmt8zwynCMFlSH+MzXO5BvUEej+H2c7d3HQIc3bO26wUdVlhcQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@requestly/requestly-proxy/-/requestly-proxy-1.5.2.tgz",
+      "integrity": "sha512-dhYbLQYTXUO0rDUbmPp09MPLGPxODeH23SbBwiYTBDqMa0I2u+ySs5rs9P+5SSvcRwdwYqlJ8laWa9qBPbmp/A==",
       "requires": {
-        "@jitl/quickjs-singlefile-cjs-release-sync": "^0.32.0",
         "@requestly/requestly-core": "1.1.1",
         "@sentry/browser": "^8.33.1",
         "async": "^3.2.5",
@@ -21473,7 +21433,6 @@
         "mime-types": "^2.1.35",
         "mkdirp": "^0.5.5",
         "node-forge": "^1.3.0",
-        "quickjs-emscripten-core": "^0.32.0",
         "semaphore": "^1.1.0",
         "ua-parser-js": "^1.0.37",
         "url": "^0.11.3",
@@ -29910,14 +29869,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
-    },
-    "quickjs-emscripten-core": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/quickjs-emscripten-core/-/quickjs-emscripten-core-0.32.0.tgz",
-      "integrity": "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==",
-      "requires": {
-        "@jitl/quickjs-ffi-types": "0.32.0"
-      }
     },
     "raf": {
       "version": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.6.26",
+  "version": "26.6.29",
   "main": "src/main/main.ts",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
@@ -279,7 +279,7 @@
     "@devicefarmer/adbkit": "^3.2.6",
     "@electron/remote": "^2.1.2",
     "@requestly/requestly-core": "1.1.1",
-    "@requestly/requestly-proxy": "1.5.1",
+    "@requestly/requestly-proxy": "1.5.2",
     "@sentry/browser": "^8.34.0",
     "@sentry/electron": "^5.6.0",
     "@sinclair/typebox": "^0.34.25",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requestly",
   "productName": "Requestly",
-  "version": "26.6.26",
+  "version": "26.6.29",
   "private": true,
   "description": "Intercept & Modify HTTP Requests",
   "main": "./dist/main/main.js",


### PR DESCRIPTION
## What

- Bump `@requestly/requestly-proxy`: **1.5.1 → 1.5.2**
- Bump desktop app version: **26.6.26 → 26.6.29** (root `package.json` + `release/app/package.json`)
- Regenerate `package-lock.json` accordingly

## Why

Ships proxy `1.5.2`, which drops the QuickJS-WASM rule-code sandbox — the lockfile change removes the `quickjs-emscripten-core` / `@jitl/quickjs-*` transitive dependencies. Version follows the existing `YY.M.DD` scheme.

## Changes

| File | Change |
|------|--------|
| `package.json` | `version` → 26.6.29; proxy → 1.5.2 |
| `release/app/package.json` | `version` → 26.6.29 |
| `package-lock.json` | proxy 1.5.2 (registry-resolved) + transitive cleanup |

## Verification

- `npm install` clean; `npm ls @requestly/requestly-proxy` → `1.5.2`
- Lockfile proxy resolves to `registry.npmjs.org/.../requestly-proxy-1.5.2.tgz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app to version **26.6.29**.
  * Bumped a bundled networking component to a newer patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->